### PR TITLE
flake.nix: init

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -88,6 +88,23 @@ let
     autoPrUpdate =
       let
         updateScripts = {
+          flake = pkgs.writeShellApplication {
+            name = "update-flake";
+            runtimeInputs = with pkgs; [
+              git
+              nix
+            ];
+            text = ''
+              echo "<details><summary>flake.nix changes</summary>"
+              # Needed because GitHub's rendering of the first body line breaks down otherwise
+              echo ""
+              echo '```'
+              cd "$1"
+              nix flake update 2>&1
+              echo  '```'
+              echo "</details>"
+            '';
+          };
           npins = pkgs.writeShellApplication {
             name = "update-npins";
             runtimeInputs = with pkgs; [ npins ];
@@ -96,7 +113,7 @@ let
               # Needed because GitHub's rendering of the first body line breaks down otherwise
               echo ""
               echo '```'
-              npins update --directory "$1/npins" 2>&1
+              npins --directory "$1/npins" import-flake 2>&1
               echo  '```'
               echo "</details>"
             '';

--- a/default.nix
+++ b/default.nix
@@ -5,13 +5,15 @@ in
   system ? builtins.currentSystem,
   nixpkgs ? sources.nixpkgs,
   treefmt-nix ? sources.treefmt-nix,
+  pkgs ? (
+    import nixpkgs {
+      inherit system;
+      config = { };
+      overlays = [ ];
+    }
+  ),
 }:
 let
-  pkgs = import nixpkgs {
-    inherit system;
-    config = { };
-    overlays = [ ];
-  };
   inherit (pkgs) lib;
 
   runtimeExprPath = ./src/eval.nix;
@@ -78,6 +80,9 @@ let
         fileset = lib.fileset.gitTracked ./.;
       }
     );
+
+    # Fits in with `nix fmt`.
+    treefmtWrapper = treefmtEval.config.build.wrapper;
 
     # Run regularly by CI and turned into a PR
     autoPrUpdate =

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,47 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1715706901,
+        "narHash": "sha256-wgN9N4+cwPQnEt4JEXUgqCyMVxFtRYPdkJRUMhEsq1k=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9179dcb85960154a3ba041792e8018a8ee0cb7c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1714058656,
+        "narHash": "sha256-Qv4RBm4LKuO4fNOfx9wl40W2rBbv5u5m+whxRYUMiaA=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "c6aaf729f34a36c445618580a9f95a48f5e4e03f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715706901,
-        "narHash": "sha256-wgN9N4+cwPQnEt4JEXUgqCyMVxFtRYPdkJRUMhEsq1k=",
+        "lastModified": 1715723267,
+        "narHash": "sha256-kmDCqkXyseOohJbJB8F6IjvqLqb1N8ywdximKCGQkLc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9179dcb85960154a3ba041792e8018a8ee0cb7c7",
+        "rev": "1cd23ed4ac35f6bb8e40342b45a8efa74adb628a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "nixpkgs-check-by-name: a linter for nixpkgs";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      treefmt-nix,
+    }:
+    let
+      # Until https://github.com/NixOS/nixpkgs/pull/295083 is accepted and merged.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      eachSystem =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f (
+            import ./default.nix {
+              inherit nixpkgs system treefmt-nix;
+              pkgs = nixpkgs.legacyPackages.${system};
+            }
+          )
+        );
+    in
+    {
+      packages = eachSystem (this: {
+        default = this.build;
+      });
+
+      devShells = eachSystem (this: {
+        default = this.shell;
+      });
+
+      checks = eachSystem (this: {
+        formatting = this.treefmt;
+        nixpkgs = this.nixpkgsCheck;
+      });
+
+      formatter = eachSystem (this: this.treefmtWrapper);
+    };
+}


### PR DESCRIPTION
I like flakes. 🤷🏻‍♂️ 

* Added `flake.nix`
  * Wired up the package to the default build output for `nix build`
  * Wired up the shell to the default shell for `nix shell`
  * Wired up the two checks (for formatting and nixpkgs) to `nix flake check`.
  * Added the hydra-built systems as the default systems
* Added `nix flake update` to the update scripts
* Reshaped `default.nix` to accept `pkgs` as an input
* Added `treefmtWrapper` (per the docs on [treefmt-nix](https://github.com/numtide/treefmt-nix?tab=readme-ov-file#flakes)) that fits into `nix fmt`.