### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,9 +399,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags",
  "errno",
@@ -474,9 +474,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre670565.ae815cee91b4/nixexprs.tar.xz",
-      "hash": "1h87v5729fz27a1k90b0iy5c4bzs8b7dg747v777iss8wn4jljpb"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre674705.b833ff01a0d6/nixexprs.tar.xz",
+      "hash": "12cda9rvpgjcsxykbcg5cxjaayhibjjabv6svacjc5n5kpcbx5sf"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "070f834771efa715f3e74cd8ab93ecc96fabc951",
-      "url": "https://github.com/numtide/treefmt-nix/archive/070f834771efa715f3e74cd8ab93ecc96fabc951.tar.gz",
-      "hash": "1qbq697gmyjk3fhzamvqph6bcpaw08ifsb24zygfyfir4mm6v8lh"
+      "revision": "9fb342d14b69aefdf46187f6bb80a4a0d97007cd",
+      "url": "https://github.com/numtide/treefmt-nix/archive/9fb342d14b69aefdf46187f6bb80a4a0d97007cd.tar.gz",
+      "hash": "04afdry3plv1w1bdqs2diwdv5hz0dgyqvlv4g4d07zhf7mcv3jjm"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-vet's dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: 16 packages

```
### cargo update

```
    Updating crates.io index
     Locking 2 packages to latest compatible versions
    Updating rustix v0.38.34 -> v0.38.35
    Updating syn v2.0.76 -> v2.0.77
note: pass `--verbose` to see 13 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 652 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (86 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre670565.ae815cee91b4/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre674705.b833ff01a0d6/nixexprs.tar.xz
-    hash: 1h87v5729fz27a1k90b0iy5c4bzs8b7dg747v777iss8wn4jljpb
+    hash: 12cda9rvpgjcsxykbcg5cxjaayhibjjabv6svacjc5n5kpcbx5sf
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 070f834771efa715f3e74cd8ab93ecc96fabc951
+    revision: 9fb342d14b69aefdf46187f6bb80a4a0d97007cd
-    url: https://github.com/numtide/treefmt-nix/archive/070f834771efa715f3e74cd8ab93ecc96fabc951.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/9fb342d14b69aefdf46187f6bb80a4a0d97007cd.tar.gz
-    hash: 1qbq697gmyjk3fhzamvqph6bcpaw08ifsb24zygfyfir4mm6v8lh
+    hash: 04afdry3plv1w1bdqs2diwdv5hz0dgyqvlv4g4d07zhf7mcv3jjm
[INFO ] Update successful.
```
</details>
