### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking_lot"
@@ -536,9 +536,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.10.6"
-clap = { version = "4.5.17", features = ["derive"] }
+clap = { version = "4.5.18", features = ["derive"] }
 serde_json = "1.0.128"
 tempfile = "3.12.0"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre681909.039b72d0c738/nixexprs.tar.xz",
-      "hash": "0c3q85wfgp0v7hhbv7yv7g9xhijrfi6167lkdli6wqkp66v7fw7r"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre683804.a1d92660c6b3/nixexprs.tar.xz",
+      "hash": "0lzd1g9x7ihscdajc2g9f0jyykymw6r1lq2ir5g0shjzjf0jc5la"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "9fb342d14b69aefdf46187f6bb80a4a0d97007cd",
-      "url": "https://github.com/numtide/treefmt-nix/archive/9fb342d14b69aefdf46187f6bb80a4a0d97007cd.tar.gz",
-      "hash": "04afdry3plv1w1bdqs2diwdv5hz0dgyqvlv4g4d07zhf7mcv3jjm"
+      "revision": "35dfece10c642eb52928a48bee7ac06a59f93e9a",
+      "url": "https://github.com/numtide/treefmt-nix/archive/35dfece10c642eb52928a48bee7ac06a59f93e9a.tar.gz",
+      "hash": "16wii3pqgjbhdzcj2bm2fnpy7kjjs7lk95797la2089l0yn6i6c2"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking nixpkgs-vet's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.5.17  4.5.18     4.5.18 4.5.18 
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: pass `--verbose` to see 10 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 15 packages

```
### cargo update

```
    Updating crates.io index
     Locking 2 packages to latest compatible versions
 Downgrading once_cell v1.20.0 -> v1.19.0
    Updating unicode-width v0.1.13 -> v0.1.14 (latest: v0.2.0)
note: pass `--verbose` to see 12 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 660 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (86 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre681909.039b72d0c738/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre683804.a1d92660c6b3/nixexprs.tar.xz
-    hash: 0c3q85wfgp0v7hhbv7yv7g9xhijrfi6167lkdli6wqkp66v7fw7r
+    hash: 0lzd1g9x7ihscdajc2g9f0jyykymw6r1lq2ir5g0shjzjf0jc5la
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 9fb342d14b69aefdf46187f6bb80a4a0d97007cd
+    revision: 35dfece10c642eb52928a48bee7ac06a59f93e9a
-    url: https://github.com/numtide/treefmt-nix/archive/9fb342d14b69aefdf46187f6bb80a4a0d97007cd.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/35dfece10c642eb52928a48bee7ac06a59f93e9a.tar.gz
-    hash: 04afdry3plv1w1bdqs2diwdv5hz0dgyqvlv4g4d07zhf7mcv3jjm
+    hash: 16wii3pqgjbhdzcj2bm2fnpy7kjjs7lk95797la2089l0yn6i6c2
[INFO ] Update successful.
```
</details>
