### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "autocfg"
@@ -264,9 +264,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "linux-raw-sys"
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -470,18 +470,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -520,9 +520,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 rnix = "0.11.0"
 regex = "1.11.0"
 clap = { version = "4.5.20", features = ["derive"] }
-serde_json = "1.0.128"
+serde_json = "1.0.132"
 tempfile = "3.13.0"
-serde = { version = "1.0.210", features = ["derive"] }
+serde = { version = "1.0.213", features = ["derive"] }
 anyhow = "1.0"
 lazy_static = "1.5.0"
 colored = "2.1.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre691017.b69de56fac8c/nixexprs.tar.xz",
-      "hash": "0z32pj0lh5ng2a6cn0qfmka8cynnygckn5615mkaxq2aplkvgzx3"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre695900.782740762fb2/nixexprs.tar.xz",
+      "hash": "0gg9jkp7iq531m8520ldnng2731s3ab3wdw34yb7rw0fsg4ncxz0"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
-      "url": "https://github.com/numtide/treefmt-nix/archive/4446c7a6fc0775df028c5a3f6727945ba8400e64.tar.gz",
-      "hash": "0xyh9lwfvflagq7rk7cwbq41gx9f9s37s6kljp3wl3r860hnm566"
+      "revision": "aac86347fb5063960eccb19493e0cadcdb4205ca",
+      "url": "https://github.com/numtide/treefmt-nix/archive/aac86347fb5063960eccb19493e0cadcdb4205ca.tar.gz",
+      "hash": "0ysg99zcbq50ghjyqfkd6qkjdh74vn2ikv817rgp9mfnhfwayqsw"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
serde_json 1.0.128 1.0.132    1.0.132 1.0.132
serde      1.0.210 1.0.213    1.0.213 1.0.213
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: pass `--verbose` to see 10 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 17 packages

```
### cargo update

```
    Updating crates.io index
     Locking 3 packages to latest compatible versions
    Updating anyhow v1.0.89 -> v1.0.91
    Updating libc v0.2.159 -> v0.2.161
    Updating proc-macro2 v1.0.87 -> v1.0.89
note: pass `--verbose` to see 14 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 664 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (91 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre691017.b69de56fac8c/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre695900.782740762fb2/nixexprs.tar.xz
-    hash: 0z32pj0lh5ng2a6cn0qfmka8cynnygckn5615mkaxq2aplkvgzx3
+    hash: 0gg9jkp7iq531m8520ldnng2731s3ab3wdw34yb7rw0fsg4ncxz0
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 4446c7a6fc0775df028c5a3f6727945ba8400e64
+    revision: aac86347fb5063960eccb19493e0cadcdb4205ca
-    url: https://github.com/numtide/treefmt-nix/archive/4446c7a6fc0775df028c5a3f6727945ba8400e64.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/aac86347fb5063960eccb19493e0cadcdb4205ca.tar.gz
-    hash: 0xyh9lwfvflagq7rk7cwbq41gx9f9s37s6kljp3wl3r860hnm566
+    hash: 0ysg99zcbq50ghjyqfkd6qkjdh74vn2ikv817rgp9mfnhfwayqsw
[INFO ] Update successful.
```
</details>
