### PR TITLE
.envrc: watch npins folder

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+watch_file npins/*
+
 use nix


### PR DESCRIPTION
I was running `npins update` and noticed direnv didn't reload because it's not watching the npins folder.