### PR TITLE
Clear some clippy::pedantic pings

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4,7 +4,6 @@ use std::{env, fs, process};
 use anyhow::Context;
 use relative_path::RelativePathBuf;
 use serde::Deserialize;
-use tempfile::Builder;
 
 use crate::nix_file::CallPackageArgumentInfo;
 use crate::problem::{
@@ -157,7 +156,7 @@ pub fn check_values(
     nix_file_store: &mut NixFileStore,
     package_names: &[String],
 ) -> validation::Result<ratchet::Nixpkgs> {
-    let work_dir = Builder::new()
+    let work_dir = tempfile::Builder::new()
         .prefix("nixpkgs-vet")
         .tempdir()
         .with_context(|| "Failed to create a working directory")?;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -533,7 +533,11 @@ fn handle_non_by_name_attribute(
         // At this point, we completed two different checks for whether it's a `callPackage`.
         match (is_semantic_call_package, optional_syntactic_call_package) {
             // Something like `<attr> = { }`
-            (_, None) | (false, Some(_)) => {
+            (false, None)
+            // Something like `<attr> = pythonPackages.callPackage ...`
+            | (false, Some(_))
+            // Something like `<attr> = bar` where `bar = pkgs.callPackage ...`
+            | (true, None) => {
                 // In all of these cases, it's not possible to migrate the package to
                 // `pkgs/by-name`.
                 NonApplicable

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -155,7 +155,7 @@ fn mutate_nix_instatiate_arguments_based_on_cfg(
 pub fn check_values(
     nixpkgs_path: &Path,
     nix_file_store: &mut NixFileStore,
-    package_names: Vec<String>,
+    package_names: &[String],
 ) -> validation::Result<ratchet::Nixpkgs> {
     let work_dir = Builder::new()
         .prefix("nixpkgs-vet")
@@ -534,11 +534,7 @@ fn handle_non_by_name_attribute(
         // At this point, we completed two different checks for whether it's a `callPackage`.
         match (is_semantic_call_package, optional_syntactic_call_package) {
             // Something like `<attr> = { }`
-            (false, None)
-            // Something like `<attr> = pythonPackages.callPackage ...`
-            | (false, Some(_))
-            // Something like `<attr> = bar` where `bar = pkgs.callPackage ...`
-            | (true, None) => {
+            (_, None) | (false, Some(_)) => {
                 // In all of these cases, it's not possible to migrate the package to
                 // `pkgs/by-name`.
                 NonApplicable

--- a/src/location.rs
+++ b/src/location.rs
@@ -45,8 +45,7 @@ impl LineIndex {
     pub fn line(&self, index: usize) -> usize {
         match self.newlines.binary_search(&index) {
             // +1 because lines are 1-indexed
-            Ok(x) => x + 1,
-            Err(x) => x + 1,
+            Ok(x) | Err(x) => x + 1,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,7 +252,8 @@ mod tests {
 
         let actual_errors = format!("{status}\n");
 
-        assert!(expected_errors_regex.is_match(&actual_errors),
+        assert!(
+            expected_errors_regex.is_match(&actual_errors),
             "Failed test case {name}: {}",
             StrComparison::new(expected_errors, &actual_errors)
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,10 @@
+// #![warn(clippy::pedantic)]
+// #![allow(clippy::uninlined_format_args)]
+// #![allow(clippy::enum_glob_use)]
+// #![allow(clippy::module_name_repetitions)]
+// #![allow(clippy::doc_markdown)]
+// #![allow(clippy::if_not_else)]
+// #![allow(clippy::ignored_unit_patterns)]
 mod eval;
 mod location;
 mod nix_file;
@@ -112,7 +119,7 @@ fn check_nixpkgs(nixpkgs_path: &Path) -> validation::Result<ratchet::Nixpkgs> {
 
     // Only if we could successfully parse the structure, we do the evaluation checks
     let result = structure.result_map(|package_names| {
-        eval::check_values(&nixpkgs_path, &mut nix_file_store, package_names)
+        eval::check_values(&nixpkgs_path, &mut nix_file_store, package_names.as_slice())
     })?;
 
     Ok(result)
@@ -209,7 +216,7 @@ mod tests {
                 "symlinked_tmpdir",
                 Path::new("tests/success"),
                 "Validated successfully\n",
-            )
+            );
         });
         Ok(())
     }
@@ -245,12 +252,10 @@ mod tests {
 
         let actual_errors = format!("{status}\n");
 
-        if !expected_errors_regex.is_match(&actual_errors) {
-            panic!(
-                "Failed test case {name}: {}",
-                StrComparison::new(expected_errors, &actual_errors)
-            );
-        }
+        assert!(expected_errors_regex.is_match(&actual_errors),
+            "Failed test case {name}: {}",
+            StrComparison::new(expected_errors, &actual_errors)
+        );
     }
 
     /// Check whether a path is in a case-insensitive filesystem

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -566,7 +566,7 @@ mod tests {
             (
                 Position { line, column },
                 result
-                    .map(|node| node.to_string())
+                    .map(ToString::to_string)
                     .map_right(|node| node.to_string()),
             )
         }));
@@ -589,7 +589,7 @@ mod tests {
     fn detects_call_package() -> anyhow::Result<()> {
         let temp_dir = tests::tempdir()?;
         let file = temp_dir.path().join("file.nix");
-        let contents = indoc! {r#"
+        let contents = indoc! {r"
             self: with self; {
               a.sub = null;
               b = null;
@@ -601,7 +601,7 @@ mod tests {
               h = callPackage ./file.nix { x = 0; };
               i = callPackage ({ }: { }) (let in { });
             }
-        "#};
+        "};
 
         std::fs::write(&file, contents)?;
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -27,7 +27,7 @@ pub fn read_dir_sorted(base_dir: &Path) -> anyhow::Result<Vec<DirEntry>> {
 
     process_results(listing, |listing| {
         use itertools::Itertools;
-        Itertools::collect_vec(listing.sorted_by_key(|entry| entry.file_name()))
+        Itertools::collect_vec(listing.sorted_by_key(DirEntry::file_name))
     })
     .with_context(ctx)
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -78,9 +78,8 @@ impl Validation<()> {
     pub fn and<A>(self, other: Validation<A>) -> Validation<A> {
         match (self, other) {
             (Success(_), Success(right_value)) => Success(right_value),
-            (Failure(errors), Success(_)) => Failure(errors),
-            (Success(_), Failure(errors)) => Failure(errors),
             (Failure(errors_l), Failure(errors_r)) => Failure(concat([errors_l, errors_r])),
+            (Failure(errors), Success(_)) | (Success(_), Failure(errors)) => Failure(errors),
         }
     }
 }


### PR DESCRIPTION
This PR is probably one (tiny) step above scraping doc-comments and passing it through a spell-checker. I just ran clippy with `#![warn(clippy::pedantic)]`, clearing the lints and/or specifically allowing lints until it was clear. I just hope this is a net positive for you.

I noticed this project mentioned in the nixconf recording, and thought I'd have a look. This is a first-pass, and would be happy to provide more substantive PRs.