### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,36 +28,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -126,9 +126,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -445,9 +445,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags",
  "errno",
@@ -520,9 +520,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 rnix = "0.11.0"
-regex = "1.11.0"
+regex = "1.11.1"
 clap = { version = "4.5.20", features = ["derive"] }
 serde_json = "1.0.132"
 tempfile = "3.13.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre695900.782740762fb2/nixexprs.tar.xz",
-      "hash": "0gg9jkp7iq531m8520ldnng2731s3ab3wdw34yb7rw0fsg4ncxz0"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre697431.86e78d3d2084/nixexprs.tar.xz",
+      "hash": "0wbmh3jc25xan6x6nndfidgkfigip49zqp0rivi6lsdv18sx9mvx"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "aac86347fb5063960eccb19493e0cadcdb4205ca",
-      "url": "https://github.com/numtide/treefmt-nix/archive/aac86347fb5063960eccb19493e0cadcdb4205ca.tar.gz",
-      "hash": "0ysg99zcbq50ghjyqfkd6qkjdh74vn2ikv817rgp9mfnhfwayqsw"
+      "revision": "9ef337e492a5555d8e17a51c911ff1f02635be15",
+      "url": "https://github.com/numtide/treefmt-nix/archive/9ef337e492a5555d8e17a51c911ff1f02635be15.tar.gz",
+      "hash": "0abi3v696qs7sy0448z4q1knsvppmdl9nbzrvxlzv5rb2cixi89f"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name  old req compatible latest new req
====  ======= ========== ====== =======
regex 1.11.0  1.11.1     1.11.1 1.11.1 
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: pass `--verbose` to see 10 unchanged dependencies behind latest
note: Re-run with `--verbose` to show more dependencies
  latest: 18 packages

```
### cargo update

```
    Updating crates.io index
     Locking 8 packages to latest compatible versions
    Updating anstream v0.6.15 -> v0.6.17
    Updating anstyle v1.0.8 -> v1.0.9
    Updating anstyle-parse v0.2.5 -> v0.2.6
    Updating anstyle-query v1.1.1 -> v1.1.2
    Updating anstyle-wincon v3.0.4 -> v3.0.6
    Updating colorchoice v1.0.2 -> v1.0.3
    Updating rustix v0.38.37 -> v0.38.38
    Updating syn v2.0.82 -> v2.0.85
note: pass `--verbose` to see 14 unchanged dependencies behind latest

```
### cargo outdated

```
All dependencies are up to date, yay!

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 664 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (91 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre695900.782740762fb2/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre697431.86e78d3d2084/nixexprs.tar.xz
-    hash: 0gg9jkp7iq531m8520ldnng2731s3ab3wdw34yb7rw0fsg4ncxz0
+    hash: 0wbmh3jc25xan6x6nndfidgkfigip49zqp0rivi6lsdv18sx9mvx
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: aac86347fb5063960eccb19493e0cadcdb4205ca
+    revision: 9ef337e492a5555d8e17a51c911ff1f02635be15
-    url: https://github.com/numtide/treefmt-nix/archive/aac86347fb5063960eccb19493e0cadcdb4205ca.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/9ef337e492a5555d8e17a51c911ff1f02635be15.tar.gz
-    hash: 0ysg99zcbq50ghjyqfkd6qkjdh74vn2ikv817rgp9mfnhfwayqsw
+    hash: 0abi3v696qs7sy0448z4q1knsvppmdl9nbzrvxlzv5rb2cixi89f
[INFO ] Update successful.
```
</details>
