### PR TITLE
Replace lazy_static with std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,6 @@ dependencies = [
  "derive_more",
  "indoc",
  "itertools",
- "lazy_static",
  "pretty_assertions",
  "regex",
  "relative-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ serde_json = "1.0.132"
 tempfile = "3.13.0"
 serde = { version = "1.0.213", features = ["derive"] }
 anyhow = "1.0"
-lazy_static = "1.5.0"
 colored = "2.1.0"
 itertools = "0.13.0"
 rowan = "0.15.16"

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -1,9 +1,9 @@
 use std::fs::DirEntry;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use anyhow::Context;
 use itertools::{concat, process_results};
-use lazy_static::lazy_static;
 use regex::Regex;
 use relative_path::RelativePathBuf;
 
@@ -15,10 +15,10 @@ use crate::NixFileStore;
 pub const BASE_SUBPATH: &str = "pkgs/by-name";
 pub const PACKAGE_NIX_FILENAME: &str = "package.nix";
 
-lazy_static! {
-    static ref SHARD_NAME_REGEX: Regex = Regex::new(r"^[a-z0-9_-]{1,2}$").unwrap();
-    static ref PACKAGE_NAME_REGEX: Regex = Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
-}
+static SHARD_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-z0-9_-]{1,2}$").unwrap());
+static PACKAGE_NAME_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap());
 
 /// Deterministic file listing so that tests are reproducible.
 pub fn read_dir_sorted(base_dir: &Path) -> anyhow::Result<Vec<DirEntry>> {


### PR DESCRIPTION
lazy_static is no longer needed. We can just use this from std:

https://doc.rust-lang.org/std/sync/struct.LazyLock.html

note: no difference in compile times before / after on my machine. Think compile times are dominated by clap (edit actually maybe regex-syntax in regex crate which can't be removed easily).