### PR TITLE
Fix most clippy pedantic and nursery lint warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,17 @@ The most important tools and commands in this environment are:
   ```bash
   cargo test
   ```
-- Linting and formatting:
+- Formatting:
+  ```bash
+  treefmt
+  ```
+- Linting:
   ```bash
   cargo clippy --all-targets
-  treefmt
+  ```
+  Or optionally:
+  ```bash
+  cargo clippy --all-targets -- -W clippy::nursery -W clippy::pedantic
   ```
 - Running the [main CI checks](./.github/workflows/main.yml) locally:
   ```bash

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -13,7 +13,7 @@ use crate::ratchet::State::{Loose, Tight};
 use crate::structure::{self, BASE_SUBPATH};
 use crate::validation::ResultIteratorExt as _;
 use crate::validation::{self, Validation::Success};
-use crate::NixFileStore;
+use crate::nix_file::Store;
 use crate::{location, ratchet};
 
 const EVAL_NIX: &[u8] = include_bytes!("eval.nix");
@@ -154,7 +154,7 @@ fn mutate_nix_instatiate_arguments_based_on_cfg(
 /// achieved on the Nix side.
 pub fn check_values(
     nixpkgs_path: &Path,
-    nix_file_store: &mut NixFileStore,
+    nix_file_store: &mut Store,
     package_names: &[String],
 ) -> validation::Result<ratchet::Nixpkgs> {
     let work_dir = tempfile::Builder::new()
@@ -263,7 +263,7 @@ pub fn check_values(
 
 /// Handle the evaluation result for an attribute in `pkgs/by-name`, making it a validation result.
 fn by_name(
-    nix_file_store: &mut NixFileStore,
+    nix_file_store: &mut Store,
     nixpkgs_path: &Path,
     attribute_name: &str,
     by_name_attribute: ByNameAttribute,
@@ -450,7 +450,7 @@ fn by_name_override(
 /// validation result.
 fn handle_non_by_name_attribute(
     nixpkgs_path: &Path,
-    nix_file_store: &mut NixFileStore,
+    nix_file_store: &mut Store,
     attribute_name: &str,
     non_by_name_attribute: NonByNameAttribute,
 ) -> validation::Result<ratchet::Package> {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -9,7 +9,7 @@ use crate::nix_file::CallPackageArgumentInfo;
 use crate::problem::{
     npv_100, npv_101, npv_102, npv_103, npv_104, npv_105, npv_106, npv_107, npv_108, npv_120,
 };
-use crate::ratchet::State::{Loose, Tight};
+use crate::ratchet::RatchetState::{Loose, Tight};
 use crate::structure::{self, BASE_SUBPATH};
 use crate::validation::ResultIteratorExt as _;
 use crate::validation::{self, Validation::Success};
@@ -398,7 +398,7 @@ fn by_name_override(
     optional_syntactic_call_package: Option<CallPackageArgumentInfo>,
     definition: String,
     location: location::Location,
-) -> validation::Validation<ratchet::State<ratchet::ManualDefinition>> {
+) -> validation::Validation<ratchet::RatchetState<ratchet::ManualDefinition>> {
     let Some(syntactic_call_package) = optional_syntactic_call_package else {
         // Something like `<attr> = foo`
         return npv_104::ByNameOverrideOfNonSyntacticCallPackage::new(
@@ -455,7 +455,7 @@ fn handle_non_by_name_attribute(
     attribute_name: &str,
     non_by_name_attribute: NonByNameAttribute,
 ) -> validation::Result<ratchet::Package> {
-    use ratchet::State::{Loose, NonApplicable, Tight};
+    use ratchet::RatchetState::{Loose, NonApplicable, Tight};
     use NonByNameAttribute::EvalSuccess;
 
     // The ratchet state whether this attribute uses `pkgs/by-name`.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -531,6 +531,10 @@ fn handle_non_by_name_attribute(
             })?;
 
         // At this point, we completed two different checks for whether it's a `callPackage`.
+
+        // Allow pedantic lint: https://rust-lang.github.io/rust-clippy/master/index.html#unnested_or_patterns
+        // fixing it hurts readability of code due to comment restructuring
+        #[allow(clippy::unnested_or_patterns)]
         match (is_semantic_call_package, optional_syntactic_call_package) {
             // Something like `<attr> = { }`
             (false, None)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6,6 +6,7 @@ use relative_path::RelativePathBuf;
 use serde::Deserialize;
 
 use crate::nix_file::CallPackageArgumentInfo;
+use crate::nix_file::Store;
 use crate::problem::{
     npv_100, npv_101, npv_102, npv_103, npv_104, npv_105, npv_106, npv_107, npv_108, npv_120,
 };
@@ -13,7 +14,6 @@ use crate::ratchet::State::{Loose, Tight};
 use crate::structure::{self, BASE_SUBPATH};
 use crate::validation::ResultIteratorExt as _;
 use crate::validation::{self, Validation::Success};
-use crate::nix_file::Store;
 use crate::{location, ratchet};
 
 const EVAL_NIX: &[u8] = include_bytes!("eval.nix");

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -453,8 +453,8 @@ fn handle_non_by_name_attribute(
     attribute_name: &str,
     non_by_name_attribute: NonByNameAttribute,
 ) -> validation::Result<ratchet::Package> {
-    use ratchet::RatchetState::*;
-    use NonByNameAttribute::*;
+    use ratchet::RatchetState::{Loose, NonApplicable, Tight};
+    use NonByNameAttribute::EvalSuccess;
 
     // The ratchet state whether this attribute uses `pkgs/by-name`.
     //

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6,7 +6,6 @@ use relative_path::RelativePathBuf;
 use serde::Deserialize;
 
 use crate::nix_file::CallPackageArgumentInfo;
-use crate::nix_file::Store;
 use crate::problem::{
     npv_100, npv_101, npv_102, npv_103, npv_104, npv_105, npv_106, npv_107, npv_108, npv_120,
 };
@@ -14,6 +13,7 @@ use crate::ratchet::State::{Loose, Tight};
 use crate::structure::{self, BASE_SUBPATH};
 use crate::validation::ResultIteratorExt as _;
 use crate::validation::{self, Validation::Success};
+use crate::NixFileStore;
 use crate::{location, ratchet};
 
 const EVAL_NIX: &[u8] = include_bytes!("eval.nix");
@@ -154,7 +154,7 @@ fn mutate_nix_instatiate_arguments_based_on_cfg(
 /// achieved on the Nix side.
 pub fn check_values(
     nixpkgs_path: &Path,
-    nix_file_store: &mut Store,
+    nix_file_store: &mut NixFileStore,
     package_names: &[String],
 ) -> validation::Result<ratchet::Nixpkgs> {
     let work_dir = tempfile::Builder::new()
@@ -263,7 +263,7 @@ pub fn check_values(
 
 /// Handle the evaluation result for an attribute in `pkgs/by-name`, making it a validation result.
 fn by_name(
-    nix_file_store: &mut Store,
+    nix_file_store: &mut NixFileStore,
     nixpkgs_path: &Path,
     attribute_name: &str,
     by_name_attribute: ByNameAttribute,
@@ -451,7 +451,7 @@ fn by_name_override(
 /// validation result.
 fn handle_non_by_name_attribute(
     nixpkgs_path: &Path,
-    nix_file_store: &mut Store,
+    nix_file_store: &mut NixFileStore,
     attribute_name: &str,
     non_by_name_attribute: NonByNameAttribute,
 ) -> validation::Result<ratchet::Package> {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -315,14 +315,15 @@ fn by_name(
                 // Though this gets detected by checking whether the internal
                 // `_internalCallByNamePackageFile` was used
                 DefinitionVariant::AutoDefinition => {
-                    if let Some(_location) = location {
-                        // Such an automatic definition should definitely not have a location.
-                        // Having one indicates that somebody is using
-                        // `_internalCallByNamePackageFile`,
-                        npv_102::ByNameInternalCallPackageUsed::new(attribute_name).into()
-                    } else {
-                        Success(Tight)
-                    }
+                    location.map_or_else(
+                        || Success(Tight),
+                        |_location| {
+                            // Such an automatic definition should definitely not have a location.
+                            // Having one indicates that somebody is using
+                            // `_internalCallByNamePackageFile`,
+                            npv_102::ByNameInternalCallPackageUsed::new(attribute_name).into()
+                        },
+                    )
                 }
                 // The attribute is manually defined, e.g. in `all-packages.nix`.
                 // This means we need to enforce it to look like this:

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -352,8 +352,7 @@ fn by_name(
                             )
                             .with_context(|| {
                                 format!(
-                                    "Failed to get the definition info for attribute {}",
-                                    attribute_name
+                                    "Failed to get the definition info for attribute {attribute_name}"
                                 )
                             })?;
 
@@ -527,7 +526,7 @@ fn handle_non_by_name_attribute(
                 nixpkgs_path
             )
             .with_context(|| {
-                format!("Failed to get the definition info for attribute {}", attribute_name)
+                format!("Failed to get the definition info for attribute {attribute_name}")
             })?;
 
         // At this point, we completed two different checks for whether it's a `callPackage`.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -9,7 +9,7 @@ use crate::nix_file::CallPackageArgumentInfo;
 use crate::problem::{
     npv_100, npv_101, npv_102, npv_103, npv_104, npv_105, npv_106, npv_107, npv_108, npv_120,
 };
-use crate::ratchet::RatchetState::{Loose, Tight};
+use crate::ratchet::State::{Loose, Tight};
 use crate::structure::{self, BASE_SUBPATH};
 use crate::validation::ResultIteratorExt as _;
 use crate::validation::{self, Validation::Success};
@@ -397,7 +397,7 @@ fn by_name_override(
     optional_syntactic_call_package: Option<CallPackageArgumentInfo>,
     definition: String,
     location: location::Location,
-) -> validation::Validation<ratchet::RatchetState<ratchet::ManualDefinition>> {
+) -> validation::Validation<ratchet::State<ratchet::ManualDefinition>> {
     let Some(syntactic_call_package) = optional_syntactic_call_package else {
         // Something like `<attr> = foo`
         return npv_104::ByNameOverrideOfNonSyntacticCallPackage::new(
@@ -454,7 +454,7 @@ fn handle_non_by_name_attribute(
     attribute_name: &str,
     non_by_name_attribute: NonByNameAttribute,
 ) -> validation::Result<ratchet::Package> {
-    use ratchet::RatchetState::{Loose, NonApplicable, Tight};
+    use ratchet::State::{Loose, NonApplicable, Tight};
     use NonByNameAttribute::EvalSuccess;
 
     // The ratchet state whether this attribute uses `pkgs/by-name`.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -115,6 +115,7 @@ fn pass_through_environment_variables_for_nix_eval_in_nix_build(command: &mut pr
 }
 
 #[cfg(not(test))]
+#[allow(clippy::unnecessary_wraps)]
 fn mutate_nix_instatiate_arguments_based_on_cfg(
     _work_dir_path: &Path,
     command: &mut process::Command,

--- a/src/location.rs
+++ b/src/location.rs
@@ -28,7 +28,7 @@ pub struct LineIndex {
 }
 
 impl LineIndex {
-    pub fn new(s: &str) -> LineIndex {
+    pub fn new(s: &str) -> Self {
         let mut newlines = vec![];
         let mut index = 0;
         // Iterates over all newline-split parts of the string, adding the index of the newline to
@@ -37,7 +37,7 @@ impl LineIndex {
             index += split.len();
             newlines.push(index - 1);
         }
-        LineIndex { newlines }
+        Self { newlines }
     }
 
     /// Returns the line number for a string index.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::{panic, thread};
 
+use crate::nix_file::NixFileStore;
 use crate::status::{ColoredStatus, Status};
 use crate::validation::Validation::Failure;
 use crate::validation::Validation::Success;
@@ -107,7 +108,7 @@ fn check_nixpkgs(nixpkgs_path: &Path) -> validation::Result<ratchet::Nixpkgs> {
         return Ok(Success(ratchet::Nixpkgs::default()));
     }
 
-    let mut nix_file_store = nix_file::Store::default();
+    let mut nix_file_store = NixFileStore::default();
     let structure = structure::check(&nixpkgs_path, &mut nix_file_store)?;
 
     // Only if we could successfully parse the structure, we do the evaluation checks

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
 #![warn(clippy::pedantic, clippy::nursery)]
+// too many false-positives. discussion:
+// https://github.com/NixOS/nixpkgs-vet/pull/124#pullrequestreview-2405109643
+#![allow(clippy::module_name_repetitions)]
 
 mod eval;
 mod location;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,6 @@ use std::{panic, thread};
 
 use crate::nix_file::NixFileStore;
 use crate::status::{ColoredStatus, Status};
-use crate::structure::check_structure;
 use crate::validation::Validation::Failure;
 use crate::validation::Validation::Success;
 
@@ -115,7 +114,7 @@ fn check_nixpkgs(nixpkgs_path: &Path) -> validation::Result<ratchet::Nixpkgs> {
     }
 
     let mut nix_file_store = NixFileStore::default();
-    let structure = check_structure(&nixpkgs_path, &mut nix_file_store)?;
+    let structure = structure::check(&nixpkgs_path, &mut nix_file_store)?;
 
     // Only if we could successfully parse the structure, we do the evaluation checks
     let result = structure.result_map(|package_names| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use std::{panic, thread};
 
 use crate::nix_file::NixFileStore;
 use crate::status::{ColoredStatus, Status};
+use crate::structure::check_structure;
 use crate::validation::Validation::Failure;
 use crate::validation::Validation::Success;
 
@@ -112,7 +113,7 @@ fn check_nixpkgs(nixpkgs_path: &Path) -> validation::Result<ratchet::Nixpkgs> {
     }
 
     let mut nix_file_store = NixFileStore::default();
-    let structure = structure::check(&nixpkgs_path, &mut nix_file_store)?;
+    let structure = check_structure(&nixpkgs_path, &mut nix_file_store)?;
 
     // Only if we could successfully parse the structure, we do the evaluation checks
     let result = structure.result_map(|package_names| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,5 @@
-// #![warn(clippy::pedantic)]
-// #![allow(clippy::uninlined_format_args)]
-// #![allow(clippy::enum_glob_use)]
-// #![allow(clippy::module_name_repetitions)]
-// #![allow(clippy::doc_markdown)]
-// #![allow(clippy::if_not_else)]
-// #![allow(clippy::ignored_unit_patterns)]
+#![warn(clippy::pedantic)]
+
 mod eval;
 mod location;
 mod nix_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,3 @@
-#![warn(clippy::pedantic, clippy::nursery)]
-// too many false-positives. discussion:
-// https://github.com/NixOS/nixpkgs-vet/pull/124#pullrequestreview-2405109643
-#![allow(clippy::module_name_repetitions)]
-
 mod eval;
 mod location;
 mod nix_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::pedantic)]
+#![warn(clippy::pedantic, clippy::nursery)]
 
 mod eval;
 mod location;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::{panic, thread};
 
-use crate::nix_file::NixFileStore;
 use crate::status::{ColoredStatus, Status};
 use crate::validation::Validation::Failure;
 use crate::validation::Validation::Success;
@@ -113,7 +112,7 @@ fn check_nixpkgs(nixpkgs_path: &Path) -> validation::Result<ratchet::Nixpkgs> {
         return Ok(Success(ratchet::Nixpkgs::default()));
     }
 
-    let mut nix_file_store = NixFileStore::default();
+    let mut nix_file_store = nix_file::Store::default();
     let structure = structure::check(&nixpkgs_path, &mut nix_file_store)?;
 
     // Only if we could successfully parse the structure, we do the evaluation checks

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -143,7 +143,7 @@ impl NixFile {
             Right(attrpath_value) => {
                 let definition = attrpath_value.to_string();
                 let attrpath_value =
-                    self.attrpath_value_call_package_argument_info(attrpath_value, relative_to)?;
+                    self.attrpath_value_call_package_argument_info(&attrpath_value, relative_to)?;
                 (attrpath_value, definition)
             }
         })
@@ -252,7 +252,7 @@ impl NixFile {
     // Internal function mainly to make `attrpath_value_at` independently testable.
     fn attrpath_value_call_package_argument_info(
         &self,
-        attrpath_value: ast::AttrpathValue,
+        attrpath_value: &ast::AttrpathValue,
         relative_to: &Path,
     ) -> anyhow::Result<Option<CallPackageArgumentInfo>> {
         let Some(attrpath) = attrpath_value.attrpath() else {
@@ -326,7 +326,7 @@ impl NixFile {
         // Check that <arg2> is a path expression.
         let path = if let Expr::Path(actual_path) = arg2 {
             // Try to statically resolve the path and turn it into a nixpkgs-relative path.
-            if let ResolvedPath::Within(p) = self.static_resolve_path(actual_path, relative_to) {
+            if let ResolvedPath::Within(p) = self.static_resolve_path(&actual_path, relative_to) {
                 Some(p)
             } else {
                 // We can't statically know an existing path inside Nixpkgs used as <arg2>.
@@ -417,7 +417,7 @@ impl NixFile {
     ///
     /// Given the path expression `./bar.nix` in `./foo.nix` and an absolute path of the
     /// current directory, the function returns `ResolvedPath::Within(./bar.nix)`.
-    pub fn static_resolve_path(&self, node: ast::Path, relative_to: &Path) -> ResolvedPath {
+    pub fn static_resolve_path(&self, node: &ast::Path, relative_to: &Path) -> ResolvedPath {
         if node.parts().count() != 1 {
             // If there's more than 1 interpolated part, it's of the form `./foo/${bar}/baz`.
             return ResolvedPath::Interpolated;

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -48,7 +48,7 @@ pub struct NixFile {
 }
 
 impl NixFile {
-    /// Creates a new NixFile, failing for I/O or parse errors.
+    /// Creates a new `NixFile`, failing for I/O or parse errors.
     fn new(path: impl AsRef<Path>) -> anyhow::Result<NixFile> {
         let Some(parent_dir) = path.as_ref().parent() else {
             anyhow::bail!("Could not get parent of path {}", path.as_ref().display())
@@ -116,7 +116,7 @@ impl NixFile {
     ///
     ///   results in `{ file = ./default.nix; line = 2; column = 3; }`
     ///
-    /// - Get the NixFile for `.file` from a `NixFileStore`
+    /// - Get the `NixFile` for `.file` from a `NixFileStore`
     ///
     /// - Call this function with `.line`, `.column` and `relative_to` as the (absolute) current
     ///   directory.

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -78,7 +78,7 @@ impl NixFile {
 }
 
 /// Information about `callPackage` arguments.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CallPackageArgumentInfo {
     /// The relative path of the first argument, or `None` if it's not a path.
     pub relative_path: Option<RelativePathBuf>,

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -160,7 +160,7 @@ impl NixFile {
         let token_at_offset = self
             .syntax_root
             .syntax()
-            .token_at_offset(TextSize::from(index as u32));
+            .token_at_offset(TextSize::from(u32::try_from(index)?));
 
         // The token_at_offset function takes indices to mean a location _between_ characters,
         // which in this case is some spacing followed by the attribute name:

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -19,11 +19,11 @@ use std::path::PathBuf;
 /// A structure to store parse results of Nix files in memory, making sure that the same file never
 /// has to be parsed twice.
 #[derive(Default)]
-pub struct NixFileStore {
+pub struct Store {
     entries: HashMap<PathBuf, NixFile>,
 }
 
-impl NixFileStore {
+impl Store {
     /// Get the store entry for a Nix file if it exists, otherwise parse the file, insert it into
     /// the store, and return the value.
     ///
@@ -116,7 +116,7 @@ impl NixFile {
     ///
     ///   results in `{ file = ./default.nix; line = 2; column = 3; }`
     ///
-    /// - Get the `NixFile` for `.file` from a `NixFileStore`
+    /// - Get the `NixFile` for `.file` from a `nix_file::Store`
     ///
     /// - Call this function with `.line`, `.column` and `relative_to` as the (absolute) current
     ///   directory.

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -49,7 +49,7 @@ pub struct NixFile {
 
 impl NixFile {
     /// Creates a new `NixFile`, failing for I/O or parse errors.
-    fn new(path: impl AsRef<Path>) -> anyhow::Result<NixFile> {
+    fn new(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let Some(parent_dir) = path.as_ref().parent() else {
             anyhow::bail!("Could not get parent of path {}", path.as_ref().display())
         };
@@ -67,7 +67,7 @@ impl NixFile {
             // rnix's `rnix::Parse::ok` returns `Result<_, _>`, so no error is thrown away like it
             // would be with `std::result::Result::ok`.
             .ok()
-            .map(|syntax_root| NixFile {
+            .map(|syntax_root| Self {
                 parent_dir: parent_dir.to_path_buf(),
                 path: path.as_ref().to_owned(),
                 syntax_root,

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -563,10 +563,7 @@ mod tests {
             (24, 11, Left("testL")),
         ];
         let expected = BTreeMap::from_iter(cases.map(|(line, column, result)| {
-            (
-                Position { line, column },
-                result.map(ToString::to_string),
-            )
+            (Position { line, column }, result.map(ToString::to_string))
         }));
         let actual = BTreeMap::from_iter(cases.map(|(line, column, _)| {
             (

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -19,11 +19,11 @@ use std::path::PathBuf;
 /// A structure to store parse results of Nix files in memory, making sure that the same file never
 /// has to be parsed twice.
 #[derive(Default)]
-pub struct Store {
+pub struct NixFileStore {
     entries: HashMap<PathBuf, NixFile>,
 }
 
-impl Store {
+impl NixFileStore {
     /// Get the store entry for a Nix file if it exists, otherwise parse the file, insert it into
     /// the store, and return the value.
     ///
@@ -116,7 +116,7 @@ impl NixFile {
     ///
     ///   results in `{ file = ./default.nix; line = 2; column = 3; }`
     ///
-    /// - Get the `NixFile` for `.file` from a `nix_file::Store`
+    /// - Get the `NixFile` for `.file` from a `NixFileStore`
     ///
     /// - Call this function with `.line`, `.column` and `relative_to` as the (absolute) current
     ///   directory.

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -565,9 +565,7 @@ mod tests {
         let expected = BTreeMap::from_iter(cases.map(|(line, column, result)| {
             (
                 Position { line, column },
-                result
-                    .map(ToString::to_string)
-                    .map_right(|node| node.to_string()),
+                result.map(std::string::ToString::to_string),
             )
         }));
         let actual = BTreeMap::from_iter(cases.map(|(line, column, _)| {

--- a/src/nix_file.rs
+++ b/src/nix_file.rs
@@ -565,7 +565,7 @@ mod tests {
         let expected = BTreeMap::from_iter(cases.map(|(line, column, result)| {
             (
                 Position { line, column },
-                result.map(std::string::ToString::to_string),
+                result.map(ToString::to_string),
             )
         }));
         let actual = BTreeMap::from_iter(cases.map(|(line, column, _)| {

--- a/src/problem/npv_160.rs
+++ b/src/problem/npv_160.rs
@@ -24,11 +24,9 @@ impl fmt::Display for TopLevelPackageMovedOutOfByName {
             file,
         } = self;
         let relative_package_file = structure::relative_file_for_package(package_name);
-        let call_package_arg = if let Some(path) = call_package_path {
-            format!("./{path}")
-        } else {
-            "...".into()
-        };
+        let call_package_arg = call_package_path
+            .as_ref()
+            .map_or_else(|| "...".into(), |path| format!("./{path}"));
         writedoc!(
             f,
             "

--- a/src/problem/npv_160.rs
+++ b/src/problem/npv_160.rs
@@ -25,7 +25,7 @@ impl fmt::Display for TopLevelPackageMovedOutOfByName {
         } = self;
         let relative_package_file = structure::relative_file_for_package(package_name);
         let call_package_arg = if let Some(path) = call_package_path {
-            format!("./{}", path)
+            format!("./{path}")
         } else {
             "...".into()
         };

--- a/src/problem/npv_161.rs
+++ b/src/problem/npv_161.rs
@@ -25,7 +25,7 @@ impl fmt::Display for TopLevelPackageMovedOutOfByNameWithCustomArguments {
         } = self;
         let relative_package_file = structure::relative_file_for_package(package_name);
         let call_package_arg = if let Some(path) = call_package_path {
-            format!("./{}", path)
+            format!("./{path}")
         } else {
             "...".into()
         };

--- a/src/problem/npv_161.rs
+++ b/src/problem/npv_161.rs
@@ -24,11 +24,9 @@ impl fmt::Display for TopLevelPackageMovedOutOfByNameWithCustomArguments {
             file,
         } = self;
         let relative_package_file = structure::relative_file_for_package(package_name);
-        let call_package_arg = if let Some(path) = call_package_path {
-            format!("./{path}")
-        } else {
-            "...".into()
-        };
+        let call_package_arg = call_package_path
+            .as_ref()
+            .map_or_else(|| "...".into(), |path| format!("./{path}"));
         writedoc!(
             f,
             "

--- a/src/problem/npv_162.rs
+++ b/src/problem/npv_162.rs
@@ -24,11 +24,9 @@ impl fmt::Display for NewTopLevelPackageShouldBeByName {
             file,
         } = self;
         let relative_package_file = structure::relative_file_for_package(package_name);
-        let call_package_arg = if let Some(path) = call_package_path {
-            format!("./{path}")
-        } else {
-            "...".into()
-        };
+        let call_package_arg = call_package_path
+            .as_ref()
+            .map_or_else(|| "...".into(), |path| format!("./{path}"));
         writedoc!(
             f,
             "

--- a/src/problem/npv_162.rs
+++ b/src/problem/npv_162.rs
@@ -25,7 +25,7 @@ impl fmt::Display for NewTopLevelPackageShouldBeByName {
         } = self;
         let relative_package_file = structure::relative_file_for_package(package_name);
         let call_package_arg = if let Some(path) = call_package_path {
-            format!("./{}", path)
+            format!("./{path}")
         } else {
             "...".into()
         };

--- a/src/problem/npv_163.rs
+++ b/src/problem/npv_163.rs
@@ -25,7 +25,7 @@ impl fmt::Display for NewTopLevelPackageShouldBeByNameWithCustomArgument {
         } = self;
         let relative_package_file = structure::relative_file_for_package(package_name);
         let call_package_arg = if let Some(path) = call_package_path {
-            format!("./{}", path)
+            format!("./{path}")
         } else {
             "...".into()
         };

--- a/src/problem/npv_163.rs
+++ b/src/problem/npv_163.rs
@@ -24,11 +24,9 @@ impl fmt::Display for NewTopLevelPackageShouldBeByNameWithCustomArgument {
             file,
         } = self;
         let relative_package_file = structure::relative_file_for_package(package_name);
-        let call_package_arg = if let Some(path) = call_package_path {
-            format!("./{path}")
-        } else {
-            "...".into()
-        };
+        let call_package_arg = call_package_path
+            .as_ref()
+            .map_or_else(|| "...".into(), |path| format!("./{path}"));
         writedoc!(
             f,
             "

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -35,22 +35,22 @@ impl Nixpkgs {
 /// The ratchet value for a top-level package
 pub struct Package {
     /// The ratchet value for the check for non-auto-called empty arguments
-    pub manual_definition: State<ManualDefinition>,
+    pub manual_definition: RatchetState<ManualDefinition>,
 
     /// The ratchet value for the check for new packages using pkgs/by-name
-    pub uses_by_name: State<UsesByName>,
+    pub uses_by_name: RatchetState<UsesByName>,
 }
 
 impl Package {
     /// Validates the ratchet checks for a top-level package
     pub fn compare(name: &str, optional_from: Option<&Self>, to: &Self) -> Validation<()> {
         validation::sequence_([
-            State::<ManualDefinition>::compare(
+            RatchetState::<ManualDefinition>::compare(
                 name,
                 optional_from.map(|x| &x.manual_definition),
                 &to.manual_definition,
             ),
-            State::<UsesByName>::compare(
+            RatchetState::<UsesByName>::compare(
                 name,
                 optional_from.map(|x| &x.uses_by_name),
                 &to.uses_by_name,
@@ -60,7 +60,7 @@ impl Package {
 }
 
 /// The ratchet state of a generic ratchet check.
-pub enum State<Ratchet: ToProblem> {
+pub enum RatchetState<Ratchet: ToProblem> {
     /// The ratchet is loose. It can be tightened more. In other words, this is the legacy state
     /// we're trying to move away from.
     ///
@@ -86,7 +86,7 @@ pub trait ToProblem {
     fn to_problem(name: &str, optional_from: Option<()>, to: &Self::ToContext) -> Problem;
 }
 
-impl<Context: ToProblem> State<Context> {
+impl<Context: ToProblem> RatchetState<Context> {
     /// Compare the previous ratchet state of an attribute to the new state.
     /// The previous state may be `None` in case the attribute is new.
     fn compare(name: &str, optional_from: Option<&Self>, to: &Self) -> Validation<()> {

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -21,7 +21,7 @@ pub struct Nixpkgs {
 
 impl Nixpkgs {
     /// Validates the ratchet checks for Nixpkgs
-    pub fn compare(from: Self, to: Self) -> Validation<()> {
+    pub fn compare(from: &Self, to: Self) -> Validation<()> {
         validation::sequence_(
             // We only loop over the current attributes,
             // we don't need to check ones that were removed

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -92,12 +92,12 @@ impl<Context: ToProblem> State<Context> {
     fn compare(name: &str, optional_from: Option<&Self>, to: &Self) -> Validation<()> {
         match (optional_from, to) {
             // Loosening a ratchet is not allowed.
-            (Some(State::Tight), State::Loose(loose_context)) => {
+            (Some(Self::Tight), Self::Loose(loose_context)) => {
                 Context::to_problem(name, Some(()), loose_context).into()
             }
 
             // Introducing a loose ratchet is also not allowed.
-            (None, State::Loose(loose_context)) => {
+            (None, Self::Loose(loose_context)) => {
                 Context::to_problem(name, None, loose_context).into()
             }
 

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -13,7 +13,7 @@ use crate::validation::{self, Validation, Validation::Success};
 /// The ratchet value for the entirety of Nixpkgs.
 #[derive(Default)]
 pub struct Nixpkgs {
-    /// Sorted list of packages in package_map
+    /// Sorted list of packages in `package_map`
     pub package_names: Vec<String>,
     /// The ratchet values for all packages
     pub package_map: HashMap<String, Package>,
@@ -73,7 +73,7 @@ pub enum RatchetState<Ratchet: ToProblem> {
     /// use the latest state, or because the ratchet isn't relevant.
     Tight,
 
-    /// This ratchet can't be applied. State transitions from/to NonApplicable are always allowed.
+    /// This ratchet can't be applied. State transitions from/to `NonApplicable` are always allowed.
     NonApplicable,
 }
 

--- a/src/references.rs
+++ b/src/references.rs
@@ -13,7 +13,7 @@ use crate::NixFileStore;
 
 /// Check that every package directory in pkgs/by-name doesn't link to outside that directory.
 /// Both symlinks and Nix path expressions are checked.
-pub fn check_references(
+pub fn check(
     nix_file_store: &mut NixFileStore,
     relative_package_dir: &RelativePath,
     absolute_package_dir: &Path,

--- a/src/references.rs
+++ b/src/references.rs
@@ -9,12 +9,12 @@ use crate::nix_file::ResolvedPath;
 use crate::problem::{npv_121, npv_122, npv_123, npv_124, npv_125, npv_126};
 use crate::structure::read_dir_sorted;
 use crate::validation::{self, ResultIteratorExt, Validation::Success};
-use crate::NixFileStore;
+use crate::nix_file::Store;
 
 /// Check that every package directory in pkgs/by-name doesn't link to outside that directory.
 /// Both symlinks and Nix path expressions are checked.
 pub fn check(
-    nix_file_store: &mut NixFileStore,
+    nix_file_store: &mut Store,
     relative_package_dir: &RelativePath,
     absolute_package_dir: &Path,
 ) -> validation::Result<()> {
@@ -40,7 +40,7 @@ pub fn check(
 /// A relative path so that the error messages don't get absolute paths (which are messy in CI).
 /// The absolute package directory gets prepended before doing anything with it though.
 fn check_path(
-    nix_file_store: &mut NixFileStore,
+    nix_file_store: &mut Store,
     relative_package_dir: &RelativePath,
     absolute_package_dir: &Path,
     subpath: &RelativePath,
@@ -111,7 +111,7 @@ fn check_path(
 /// Check whether a Nix file contains path expression references pointing outside the package
 /// directory.
 fn check_nix_file(
-    nix_file_store: &mut NixFileStore,
+    nix_file_store: &mut Store,
     relative_package_dir: &RelativePath,
     absolute_package_dir: &Path,
     subpath: &RelativePath,

--- a/src/references.rs
+++ b/src/references.rs
@@ -13,7 +13,7 @@ use crate::NixFileStore;
 
 /// Check that every package directory in pkgs/by-name doesn't link to outside that directory.
 /// Both symlinks and Nix path expressions are checked.
-pub fn check(
+pub fn check_references(
     nix_file_store: &mut NixFileStore,
     relative_package_dir: &RelativePath,
     absolute_package_dir: &Path,

--- a/src/references.rs
+++ b/src/references.rs
@@ -30,8 +30,7 @@ pub fn check_references(
     )
     .with_context(|| {
         format!(
-            "While checking the references in package directory {}",
-            relative_package_dir
+            "While checking the references in package directory {relative_package_dir}"
         )
     })
 }
@@ -85,7 +84,7 @@ fn check_path(
                     )
                 })
                 .collect_vec()
-                .with_context(|| format!("Error while recursing into {}", subpath))?,
+                .with_context(|| format!("Error while recursing into {subpath}"))?,
         )
     } else if path.is_file() {
         // Only check Nix files
@@ -97,7 +96,7 @@ fn check_path(
                     absolute_package_dir,
                     subpath,
                 )
-                .with_context(|| format!("Error while checking Nix file {}", subpath))?
+                .with_context(|| format!("Error while checking Nix file {subpath}"))?
             } else {
                 Success(())
             }

--- a/src/references.rs
+++ b/src/references.rs
@@ -6,10 +6,10 @@ use relative_path::RelativePath;
 use rowan::ast::AstNode;
 
 use crate::nix_file::ResolvedPath;
+use crate::nix_file::Store;
 use crate::problem::{npv_121, npv_122, npv_123, npv_124, npv_125, npv_126};
 use crate::structure::read_dir_sorted;
 use crate::validation::{self, ResultIteratorExt, Validation::Success};
-use crate::nix_file::Store;
 
 /// Check that every package directory in pkgs/by-name doesn't link to outside that directory.
 /// Both symlinks and Nix path expressions are checked.

--- a/src/references.rs
+++ b/src/references.rs
@@ -5,6 +5,7 @@ use anyhow::Context;
 use relative_path::RelativePath;
 use rowan::ast::AstNode;
 
+use crate::nix_file::ResolvedPath;
 use crate::problem::{npv_121, npv_122, npv_123, npv_124, npv_125, npv_126};
 use crate::structure::read_dir_sorted;
 use crate::validation::{self, ResultIteratorExt, Validation::Success};
@@ -130,8 +131,6 @@ fn check_nix_file(
             let Some(path) = rnix::ast::Path::cast(node) else {
                 return Success(());
             };
-
-            use crate::nix_file::ResolvedPath;
 
             match nix_file.static_resolve_path(&path, absolute_package_dir) {
                 ResolvedPath::Interpolated => npv_121::NixFileContainsPathInterpolation::new(

--- a/src/references.rs
+++ b/src/references.rs
@@ -133,7 +133,7 @@ fn check_nix_file(
 
             use crate::nix_file::ResolvedPath;
 
-            match nix_file.static_resolve_path(path, absolute_package_dir) {
+            match nix_file.static_resolve_path(&path, absolute_package_dir) {
                 ResolvedPath::Interpolated => npv_121::NixFileContainsPathInterpolation::new(
                     relative_package_dir,
                     subpath,

--- a/src/references.rs
+++ b/src/references.rs
@@ -6,15 +6,15 @@ use relative_path::RelativePath;
 use rowan::ast::AstNode;
 
 use crate::nix_file::ResolvedPath;
-use crate::nix_file::Store;
 use crate::problem::{npv_121, npv_122, npv_123, npv_124, npv_125, npv_126};
 use crate::structure::read_dir_sorted;
 use crate::validation::{self, ResultIteratorExt, Validation::Success};
+use crate::NixFileStore;
 
 /// Check that every package directory in pkgs/by-name doesn't link to outside that directory.
 /// Both symlinks and Nix path expressions are checked.
 pub fn check(
-    nix_file_store: &mut Store,
+    nix_file_store: &mut NixFileStore,
     relative_package_dir: &RelativePath,
     absolute_package_dir: &Path,
 ) -> validation::Result<()> {
@@ -40,7 +40,7 @@ pub fn check(
 /// A relative path so that the error messages don't get absolute paths (which are messy in CI).
 /// The absolute package directory gets prepended before doing anything with it though.
 fn check_path(
-    nix_file_store: &mut Store,
+    nix_file_store: &mut NixFileStore,
     relative_package_dir: &RelativePath,
     absolute_package_dir: &Path,
     subpath: &RelativePath,
@@ -111,7 +111,7 @@ fn check_path(
 /// Check whether a Nix file contains path expression references pointing outside the package
 /// directory.
 fn check_nix_file(
-    nix_file_store: &mut Store,
+    nix_file_store: &mut NixFileStore,
     relative_package_dir: &RelativePath,
     absolute_package_dir: &Path,
     subpath: &RelativePath,

--- a/src/references.rs
+++ b/src/references.rs
@@ -30,9 +30,7 @@ pub fn check_references(
         subpath,
     )
     .with_context(|| {
-        format!(
-            "While checking the references in package directory {relative_package_dir}"
-        )
+        format!("While checking the references in package directory {relative_package_dir}")
     })
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -101,6 +101,7 @@ impl fmt::Display for Status {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub struct ColoredStatus(Status);
 
 impl From<Status> for ColoredStatus {

--- a/src/status.rs
+++ b/src/status.rs
@@ -86,18 +86,18 @@ impl From<anyhow::Error> for Status {
 impl From<Status> for ExitCode {
     fn from(status: Status) -> Self {
         match status {
-            Status::ValidatedSuccessfully | Status::BranchHealed => ExitCode::SUCCESS,
+            Status::ValidatedSuccessfully | Status::BranchHealed => Self::SUCCESS,
             Status::BranchStillBroken(..)
             | Status::ProblemsIntroduced(..)
-            | Status::DiscouragedPatternedIntroduced(..) => ExitCode::from(1),
-            Status::Error(..) => ExitCode::from(2),
+            | Status::DiscouragedPatternedIntroduced(..) => Self::from(1),
+            Status::Error(..) => Self::from(2),
         }
     }
 }
 
 impl fmt::Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Status::fmt(self, f, /* use_color */ false)
+        Self::fmt(self, f, /* use_color */ false)
     }
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -101,7 +101,6 @@ impl fmt::Display for Status {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub struct ColoredStatus(Status);
 
 impl From<Status> for ColoredStatus {

--- a/src/status.rs
+++ b/src/status.rs
@@ -29,7 +29,7 @@ pub enum Status {
 }
 
 impl Status {
-    fn errors(&self) -> Option<&Vec<Problem>> {
+    const fn errors(&self) -> Option<&Vec<Problem>> {
         match self {
             Self::ValidatedSuccessfully | Self::BranchHealed | Self::Error(..) => None,
             Self::BranchStillBroken(errors)

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -106,7 +106,7 @@ pub fn check_structure(
                             path,
                             &shard_name,
                             shard_name_valid,
-                            package_entry,
+                            &package_entry,
                         )
                     })
                     .collect_vec()?;
@@ -125,7 +125,7 @@ fn check_package(
     path: &Path,
     shard_name: &str,
     shard_name_valid: bool,
-    package_entry: DirEntry,
+    package_entry: &DirEntry,
 ) -> validation::Result<String> {
     let package_path = package_entry.path();
     let package_name = package_entry.file_name().to_string_lossy().into_owned();

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -10,7 +10,7 @@ use relative_path::RelativePathBuf;
 use crate::problem::{npv_109, npv_110, npv_111, npv_140, npv_141, npv_142, npv_143, npv_144};
 use crate::references;
 use crate::validation::{self, ResultIteratorExt, Validation::Success};
-use crate::NixFileStore;
+use crate::nix_file::Store;
 
 pub const BASE_SUBPATH: &str = "pkgs/by-name";
 pub const PACKAGE_NIX_FILENAME: &str = "package.nix";
@@ -52,7 +52,7 @@ pub fn relative_file_for_package(package_name: &str) -> RelativePathBuf {
 
 /// Check the structure of Nixpkgs, returning the attribute names that are defined in
 /// `pkgs/by-name`
-pub fn check(path: &Path, nix_file_store: &mut NixFileStore) -> validation::Result<Vec<String>> {
+pub fn check(path: &Path, nix_file_store: &mut Store) -> validation::Result<Vec<String>> {
     let base_dir = path.join(BASE_SUBPATH);
 
     let shard_results = read_dir_sorted(&base_dir)?
@@ -118,7 +118,7 @@ pub fn check(path: &Path, nix_file_store: &mut NixFileStore) -> validation::Resu
 }
 
 fn check_package(
-    nix_file_store: &mut NixFileStore,
+    nix_file_store: &mut Store,
     path: &Path,
     shard_name: &str,
     shard_name_valid: bool,

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -176,7 +176,7 @@ fn check_package(
             &relative_package_dir.to_path(path),
         )?);
 
-        result.map(|_| package_name)
+        result.map(|()| package_name)
     } else {
         npv_140::PackageDirectoryIsNotDirectory::new(package_name).into()
     })

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -7,10 +7,10 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use relative_path::RelativePathBuf;
 
+use crate::nix_file::Store;
 use crate::problem::{npv_109, npv_110, npv_111, npv_140, npv_141, npv_142, npv_143, npv_144};
 use crate::references;
 use crate::validation::{self, ResultIteratorExt, Validation::Success};
-use crate::nix_file::Store;
 
 pub const BASE_SUBPATH: &str = "pkgs/by-name";
 pub const PACKAGE_NIX_FILENAME: &str = "package.nix";

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -52,10 +52,7 @@ pub fn relative_file_for_package(package_name: &str) -> RelativePathBuf {
 
 /// Check the structure of Nixpkgs, returning the attribute names that are defined in
 /// `pkgs/by-name`
-pub fn check(
-    path: &Path,
-    nix_file_store: &mut NixFileStore,
-) -> validation::Result<Vec<String>> {
+pub fn check(path: &Path, nix_file_store: &mut NixFileStore) -> validation::Result<Vec<String>> {
     let base_dir = path.join(BASE_SUBPATH);
 
     let shard_results = read_dir_sorted(&base_dir)?

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -52,7 +52,10 @@ pub fn relative_file_for_package(package_name: &str) -> RelativePathBuf {
 
 /// Check the structure of Nixpkgs, returning the attribute names that are defined in
 /// `pkgs/by-name`
-pub fn check(path: &Path, nix_file_store: &mut NixFileStore) -> validation::Result<Vec<String>> {
+pub fn check_structure(
+    path: &Path,
+    nix_file_store: &mut NixFileStore,
+) -> validation::Result<Vec<String>> {
     let base_dir = path.join(BASE_SUBPATH);
 
     let shard_results = read_dir_sorted(&base_dir)?
@@ -167,7 +170,7 @@ fn check_package(
             Success(())
         });
 
-        let result = result.and(references::check(
+        let result = result.and(references::check_references(
             nix_file_store,
             &relative_package_dir,
             &relative_package_dir.to_path(path),

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -7,10 +7,10 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use relative_path::RelativePathBuf;
 
-use crate::nix_file::Store;
 use crate::problem::{npv_109, npv_110, npv_111, npv_140, npv_141, npv_142, npv_143, npv_144};
 use crate::references;
 use crate::validation::{self, ResultIteratorExt, Validation::Success};
+use crate::NixFileStore;
 
 pub const BASE_SUBPATH: &str = "pkgs/by-name";
 pub const PACKAGE_NIX_FILENAME: &str = "package.nix";
@@ -52,7 +52,7 @@ pub fn relative_file_for_package(package_name: &str) -> RelativePathBuf {
 
 /// Check the structure of Nixpkgs, returning the attribute names that are defined in
 /// `pkgs/by-name`
-pub fn check(path: &Path, nix_file_store: &mut Store) -> validation::Result<Vec<String>> {
+pub fn check(path: &Path, nix_file_store: &mut NixFileStore) -> validation::Result<Vec<String>> {
     let base_dir = path.join(BASE_SUBPATH);
 
     let shard_results = read_dir_sorted(&base_dir)?
@@ -118,7 +118,7 @@ pub fn check(path: &Path, nix_file_store: &mut Store) -> validation::Result<Vec<
 }
 
 fn check_package(
-    nix_file_store: &mut Store,
+    nix_file_store: &mut NixFileStore,
     path: &Path,
     shard_name: &str,
     shard_name_valid: bool,

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -52,7 +52,7 @@ pub fn relative_file_for_package(package_name: &str) -> RelativePathBuf {
 
 /// Check the structure of Nixpkgs, returning the attribute names that are defined in
 /// `pkgs/by-name`
-pub fn check_structure(
+pub fn check(
     path: &Path,
     nix_file_store: &mut NixFileStore,
 ) -> validation::Result<Vec<String>> {
@@ -170,7 +170,7 @@ fn check_package(
             Success(())
         });
 
-        let result = result.and(references::check_references(
+        let result = result.and(references::check(
             nix_file_store,
             &relative_package_dir,
             &relative_package_dir.to_path(path),

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -4,7 +4,7 @@ use itertools::{
     Either::{Left, Right},
     Itertools,
 };
-use Validation::*;
+use Validation::{Failure, Success};
 
 /// The validation result of a check.  Instead of exiting at the first failure, this type can
 /// accumulate multiple failures.  This can be achieved using the functions `and`, `sequence` and

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -25,7 +25,7 @@ impl<A, P: Into<Problem>> From<P> for Validation<A> {
 
 /// A type alias representing the result of a check, either:
 ///
-/// - Err(anyhow::Error): A fatal failure, typically I/O errors.
+/// - `Err(anyhow::Error)`: A fatal failure, typically I/O errors.
 ///   Such failures are not caused by the files in Nixpkgs.
 ///   This hints at a bug in the code or a problem with the deployment.
 ///

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -77,9 +77,9 @@ impl Validation<()> {
     /// successful. The `Problem`s of both sides are returned concatenated.
     pub fn and<A>(self, other: Validation<A>) -> Validation<A> {
         match (self, other) {
-            (Success(_), Success(right_value)) => Success(right_value),
+            (Success(()), Success(right_value)) => Success(right_value),
             (Failure(errors_l), Failure(errors_r)) => Failure(concat([errors_l, errors_r])),
-            (Failure(errors), Success(_)) | (Success(_), Failure(errors)) => Failure(errors),
+            (Failure(errors), Success(_)) | (Success(()), Failure(errors)) => Failure(errors),
         }
     }
 }


### PR DESCRIPTION
After seeing https://github.com/NixOS/nixpkgs-vet/pull/120 I was looking at other pedantic lints and realized.. I must be pedantic because I like most of the suggestions lol. I think because this project is small having this on doesn't seem too painful. Let me know what you think!

edit: note different lint categories https://doc.rust-lang.org/nightly/clippy/