### PR TITLE
Ensure dependabot doesn't break over time

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -132,7 +132,8 @@ let
           githubActions = pkgs.writeShellApplication {
             name = "update-github-actions";
             runtimeInputs = with pkgs; [
-              dependabot-cli
+              dependabot-cli.withDockerImages
+              docker
               jq
               github-cli
               coreutils


### PR DESCRIPTION
The automated GitHub workflow updates were broken for some time due to dependabot's images fetched at runtime went out of sync with the binary.

While updating dependabot fixed it for now, a more permanent fix is to use the version of dependabot that pins the images at build time, introduced in
https://github.com/NixOS/nixpkgs/pull/352866 and https://github.com/NixOS/nixpkgs/pull/354085

<s>We still need to wait for the next channel update for the latter PR (https://nixpk.gs/pr-tracker.html?pr=354085) and then update the pinned Nixpkgs (https://github.com/NixOS/nixpkgs-vet/actions/workflows/update.yml) before we can merge this, but by having it open we shouldn't forget about it.</s>