### PR TITLE
Automated update

### DIFF
--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -25,7 +25,7 @@ jobs:
           echo "after=$(<pkgs/test/check-by-name/pinned-version.txt)" >> $GITHUB_ENV
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           # To trigger CI for automated PRs, we use a separate machine account
           # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@V27
+      - uses: cachix/install-nix-action@v30
 
       - name: build
         run: nix-build -A ci

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           path: repo
 
-      - uses: cachix/install-nix-action@V27
+      - uses: cachix/install-nix-action@v30
 
       - name: Run update script
         run: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ github.event_name != 'pull_request' }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           # To trigger CI for automated PRs, we use a separate machine account
           # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "colorchoice"
@@ -203,12 +203,12 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "lazy_static"
@@ -264,9 +264,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "linux-raw-sys"
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -444,9 +444,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno",
@@ -469,18 +469,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -519,9 +519,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-linebreak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.11.1"
-clap = { version = "4.5.20", features = ["derive"] }
-serde_json = "1.0.132"
+clap = { version = "4.5.21", features = ["derive"] }
+serde_json = "1.0.133"
 tempfile = "3.14.0"
-serde = { version = "1.0.214", features = ["derive"] }
+serde = { version = "1.0.215", features = ["derive"] }
 anyhow = "1.0"
 colored = "2.1.0"
 itertools = "0.13.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre704822.85f7e662eda4/nixexprs.tar.xz",
-      "hash": "0dqlz0xqd3nn49hnx943y5sfqd7nmj25s6gi1pjm907j3vbgg47k"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre715208.2c15aa59df00/nixexprs.tar.xz",
+      "hash": "1grhv1ryj80261zf0k92jqpvlwbna2r2r2a48as4fgcihv8sn076"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "746901bb8dba96d154b66492a29f5db0693dbfcc",
-      "url": "https://github.com/numtide/treefmt-nix/archive/746901bb8dba96d154b66492a29f5db0693dbfcc.tar.gz",
-      "hash": "18lrzsgksq58xlbnkaavs9r139z2rp5js9b3pc6x9mxavb9rmbxw"
+      "revision": "49717b5af6f80172275d47a418c9719a31a78b53",
+      "url": "https://github.com/numtide/treefmt-nix/archive/49717b5af6f80172275d47a418c9719a31a78b53.tar.gz",
+      "hash": "1lqmya394jiycxdz5mpz8s626bsivix14757dl17b9gbag7xr0r4"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
clap       4.5.20  4.5.21     4.5.21  4.5.21 
serde_json 1.0.132 1.0.133    1.0.133 1.0.133
serde      1.0.214 1.0.215    1.0.215 1.0.215
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: pass `--verbose` to see 10 unchanged dependencies behind latest
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rowan
  latest: 14 packages

```
### cargo update

```
    Updating crates.io index
     Locking 9 packages to latest compatible versions
    Updating clap_lex v0.7.2 -> v0.7.3
    Updating errno v0.3.9 -> v0.3.10
    Updating itoa v1.0.11 -> v1.0.14
    Updating libc v0.2.162 -> v0.2.167
    Updating proc-macro2 v1.0.89 -> v1.0.92
    Updating regex-automata v0.4.8 -> v0.4.9
    Updating rustix v0.38.40 -> v0.38.41
    Updating syn v2.0.87 -> v2.0.90
    Updating unicode-ident v1.0.13 -> v1.0.14
note: pass `--verbose` to see 15 unchanged dependencies behind latest

```
### cargo outdated

```
Name   Project  Compat  Latest  Kind    Platform
----   -------  ------  ------  ----    --------
rowan  0.15.16  ---     0.16.1  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 689 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (91 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

Bumps the actions group with 2 updates: [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) and [cachix/install-nix-action](https://github.com/cachix/install-nix-action).

Updates `peter-evans/create-pull-request` from 6 to 7
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/peter-evans/create-pull-request/releases">peter-evans/create-pull-request's releases</a>.</em></p>
<blockquote>
<h2>Create Pull Request v7.0.0</h2>
<p>:sparkles: Now supports commit signing with bot-generated tokens! See &quot;What's new&quot; below. :writing_hand::robot:</p>
<h3>Behaviour changes</h3>
<ul>
<li>Action input <code>git-token</code> has been renamed <code>branch-token</code>, to be more clear about its purpose. The <code>branch-token</code> is the token that the action will use to create and update the branch.</li>
<li>The action now handles requests that have been rate-limited by GitHub. Requests hitting a primary rate limit will retry twice, for a total of three attempts. Requests hitting a secondary rate limit will not be retried.</li>
<li>The <code>pull-request-operation</code> output now returns <code>none</code> when no operation was executed.</li>
<li>Removed deprecated output environment variable <code>PULL_REQUEST_NUMBER</code>. Please use the <code>pull-request-number</code> action output instead.</li>
</ul>
<h3>What's new</h3>
<ul>
<li>The action can now sign commits as <code>github-actions[bot]</code> when using <code>GITHUB_TOKEN</code>, or your own bot when using <a href="https://github.com/peter-evans/create-pull-request/blob/HEAD/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens">GitHub App tokens</a>. See <a href="https://github.com/peter-evans/create-pull-request/blob/HEAD/docs/concepts-guidelines.md#commit-signature-verification-for-bots">commit signing</a> for details.</li>
<li>Action input <code>draft</code> now accepts a new value <code>always-true</code>. This will set the pull request to draft status when the pull request is updated, as well as on creation.</li>
<li>A new action input <code>maintainer-can-modify</code> indicates whether <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork">maintainers can modify</a> the pull request. The default is <code>true</code>, which retains the existing behaviour of the action.</li>
<li>A new output <code>pull-request-commits-verified</code> returns <code>true</code> or <code>false</code>, indicating whether GitHub considers the signature of the branch's commits to be verified.</li>
</ul>
<h2>What's Changed</h2>
<ul>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.36 to 18.19.39 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3000">peter-evans/create-pull-request#3000</a></li>
<li>build(deps-dev): bump ts-jest from 29.1.5 to 29.2.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3008">peter-evans/create-pull-request#3008</a></li>
<li>build(deps-dev): bump prettier from 3.3.2 to 3.3.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3018">peter-evans/create-pull-request#3018</a></li>
<li>build(deps-dev): bump ts-jest from 29.2.0 to 29.2.2 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3019">peter-evans/create-pull-request#3019</a></li>
<li>build(deps-dev): bump eslint-plugin-prettier from 5.1.3 to 5.2.1 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3035">peter-evans/create-pull-request#3035</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.39 to 18.19.41 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3037">peter-evans/create-pull-request#3037</a></li>
<li>build(deps): bump undici from 6.19.2 to 6.19.4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3036">peter-evans/create-pull-request#3036</a></li>
<li>build(deps-dev): bump ts-jest from 29.2.2 to 29.2.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3038">peter-evans/create-pull-request#3038</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.41 to 18.19.42 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3070">peter-evans/create-pull-request#3070</a></li>
<li>build(deps): bump undici from 6.19.4 to 6.19.5 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3086">peter-evans/create-pull-request#3086</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.42 to 18.19.43 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3087">peter-evans/create-pull-request#3087</a></li>
<li>build(deps-dev): bump ts-jest from 29.2.3 to 29.2.4 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3088">peter-evans/create-pull-request#3088</a></li>
<li>build(deps): bump undici from 6.19.5 to 6.19.7 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3145">peter-evans/create-pull-request#3145</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.43 to 18.19.44 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3144">peter-evans/create-pull-request#3144</a></li>
<li>Update distribution by <a href="https://github.com/actions-bot"><code>@​actions-bot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3154">peter-evans/create-pull-request#3154</a></li>
<li>build(deps): bump undici from 6.19.7 to 6.19.8 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3213">peter-evans/create-pull-request#3213</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.44 to 18.19.45 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3214">peter-evans/create-pull-request#3214</a></li>
<li>Update distribution by <a href="https://github.com/actions-bot"><code>@​actions-bot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3221">peter-evans/create-pull-request#3221</a></li>
<li>build(deps-dev): bump eslint-import-resolver-typescript from 3.6.1 to 3.6.3 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3255">peter-evans/create-pull-request#3255</a></li>
<li>build(deps-dev): bump <code>@​types/node</code> from 18.19.45 to 18.19.46 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3254">peter-evans/create-pull-request#3254</a></li>
<li>build(deps-dev): bump ts-jest from 29.2.4 to 29.2.5 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3256">peter-evans/create-pull-request#3256</a></li>
<li>v7 - signed commits by <a href="https://github.com/peter-evans"><code>@​peter-evans</code></a> in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3057">peter-evans/create-pull-request#3057</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/rustycl0ck"><code>@​rustycl0ck</code></a> made their first contribution in <a href="https://redirect.github.com/peter-evans/create-pull-request/pull/3057">peter-evans/create-pull-request#3057</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/peter-evans/create-pull-request/compare/v6.1.0...v7.0.0">https://github.com/peter-evans/create-pull-request/compare/v6.1.0...v7.0.0</a></p>
<h2>Create Pull Request v6.1.0</h2>
<p>✨ Adds <code>pull-request-branch</code> as an action output.</p>
<h2>What's Changed</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/5e914681df9dc83aa4e4905692ca88beb2f9e91f"><code>5e91468</code></a> fix: support symlinks when commit signing (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3359">#3359</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/2f38cd26bfebe301a5ee90bdd6550a69dc3ef23f"><code>2f38cd2</code></a> fix: support submodules when commit signing (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3354">#3354</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/7a8aeac749996aed943101d8e7dfb0cecc06197e"><code>7a8aeac</code></a> build(deps-dev): bump eslint from 8.57.0 to 8.57.1 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3344">#3344</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/d39d596a7720fc2c61c9aa5503097fb553431b5e"><code>d39d596</code></a> build(deps-dev): bump <code>@​types/jest</code> from 29.5.12 to 29.5.13 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3343">#3343</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/f6f978fd3dc86c443f758f603d22dc554762c832"><code>f6f978f</code></a> docs: correct suggestion for bot setup (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3342">#3342</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/6cd32fd93684475c31847837f87bb135d40a2b79"><code>6cd32fd</code></a> fix: disable abbreviated commit shas in diff (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3337">#3337</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/d121e62763d8cc35b5fb1710e887d6e69a52d3a4"><code>d121e62</code></a> fix: disable diff detection for renames and copies (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3330">#3330</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/f4d66f4d5a5a7e65a185463192800c32d296ac6d"><code>f4d66f4</code></a> build(deps-dev): bump typescript from 5.5.4 to 5.6.2 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3319">#3319</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/488c869d17c8a5cb8a2f0a09471ed82c1d2a084f"><code>488c869</code></a> build(deps-dev): bump <code>@​types/node</code> from 18.19.48 to 18.19.50 (<a href="https://redirect.github.com/peter-evans/create-pull-request/issues/3320">#3320</a>)</li>
<li><a href="https://github.com/peter-evans/create-pull-request/commit/5354f85616108575685a73a0ddd2f67c26a441c3"><code>5354f85</code></a> docs: update readme</li>
<li>Additional commits viewable in <a href="https://github.com/peter-evans/create-pull-request/compare/v6...v7">compare view</a></li>
</ul>
</details>
<br />

Updates `cachix/install-nix-action` from V27 to 30
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/cachix/install-nix-action/releases">cachix/install-nix-action's releases</a>.</em></p>
<blockquote>
<h2>v30</h2>
<ul>
<li>Nix: 2.24.7 -&gt; 2.24.9, fixing <a href="https://github.com/NixOS/nix/security/advisories/GHSA-6fjr-mq49-mm2c">GHSA-6fjr-mq49-mm2c</a></li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/cachix/install-nix-action/commit/08dcb3a5e62fa31e2da3d490afc4176ef55ecd72"><code>08dcb3a</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/217">#217</a> from Enzime/bump</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/4204e15198ce9348dda13b658f2b0b45397cf9e7"><code>4204e15</code></a> nix: 2.24.8 -&gt; 2.24.9</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/6a10e2e9fdd7f91408e9f9f95bdc77cf5232b932"><code>6a10e2e</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/216">#216</a> from Mic92/nix-bump</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/2bb614e91ac4d68577f12de9f9844d1e89c80b8d"><code>2bb614e</code></a> Nix: 2.24.7 -&gt; 2.24.8</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/9f70348d77d0422624097c4b7a75563948901306"><code>9f70348</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/215">#215</a> from Mic92/nix-bump</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/4f91dc2b65dd81b86830c57b0d3bc75eb0502a25"><code>4f91dc2</code></a> Nix: 2.24.6 -&gt; 2.24.7</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/3715ab1a11cac9e991980d7b4a28d80c7ebdd8f9"><code>3715ab1</code></a> bump channel</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/1872f1ff9dba0f554710b1ed396fb6b2263ffdfd"><code>1872f1f</code></a> Nix: 2.22.1 -&gt; 2.24.6</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/e268b7aa055cc66167f27239fc889bcd1b15683c"><code>e268b7a</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/213">#213</a> from phaer/patch-1</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/5b8c65d4d79bb2d232054c72252fa78a29c36b8a"><code>5b8c65d</code></a> Update README: hardware accel is available now...</li>
<li>Additional commits viewable in <a href="https://github.com/cachix/install-nix-action/compare/V27...v30">compare view</a></li>
</ul>
</details>
<br />

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-24.11pre704822.85f7e662eda4/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre715208.2c15aa59df00/nixexprs.tar.xz
-    hash: 0dqlz0xqd3nn49hnx943y5sfqd7nmj25s6gi1pjm907j3vbgg47k
+    hash: 1grhv1ryj80261zf0k92jqpvlwbna2r2r2a48as4fgcihv8sn076
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 746901bb8dba96d154b66492a29f5db0693dbfcc
+    revision: 49717b5af6f80172275d47a418c9719a31a78b53
-    url: https://github.com/numtide/treefmt-nix/archive/746901bb8dba96d154b66492a29f5db0693dbfcc.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/49717b5af6f80172275d47a418c9719a31a78b53.tar.gz
-    hash: 18lrzsgksq58xlbnkaavs9r139z2rp5js9b3pc6x9mxavb9rmbxw
+    hash: 1lqmya394jiycxdz5mpz8s626bsivix14757dl17b9gbag7xr0r4
[INFO ] Update successful.
```
</details>
