### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "autocfg"
@@ -86,9 +86,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "hashbrown"
@@ -264,9 +264,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -444,15 +444,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -604,15 +604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.11.1"
-clap = { version = "4.5.21", features = ["derive"] }
+clap = { version = "4.5.23", features = ["derive"] }
 serde_json = "1.0.133"
 tempfile = "3.14.0"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre715208.2c15aa59df00/nixexprs.tar.xz",
-      "hash": "1grhv1ryj80261zf0k92jqpvlwbna2r2r2a48as4fgcihv8sn076"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre716975.929116e31606/nixexprs.tar.xz",
+      "hash": "1cprm71jkm2m1s5b94z9s4fbvr0f431dl3qdbvy315s6sd870jfp"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "49717b5af6f80172275d47a418c9719a31a78b53",
-      "url": "https://github.com/numtide/treefmt-nix/archive/49717b5af6f80172275d47a418c9719a31a78b53.tar.gz",
-      "hash": "1lqmya394jiycxdz5mpz8s626bsivix14757dl17b9gbag7xr0r4"
+      "revision": "357cda84af1d74626afb7fb3bc12d6957167cda9",
+      "url": "https://github.com/numtide/treefmt-nix/archive/357cda84af1d74626afb7fb3bc12d6957167cda9.tar.gz",
+      "hash": "17x9xlbzy8mjgwz7mandfsqfixaqv6jmsc0w6g5kqysx6gmak8zn"
     }
   },
   "version": 3

--- a/tests/mock-nixpkgs.nix
+++ b/tests/mock-nixpkgs.nix
@@ -92,9 +92,13 @@ let
       [ ];
 
   # All the overlays in the right order, including the user-supplied ones
-  allOverlays = [
-    autoCalledPackages
-  ] ++ optionalAllPackagesOverlay ++ optionalAliasesOverlay ++ overlays;
+  allOverlays =
+    [
+      autoCalledPackages
+    ]
+    ++ optionalAllPackagesOverlay
+    ++ optionalAliasesOverlay
+    ++ overlays;
 
   # Apply all the overlays in order to the base fixed-point function pkgsFun
   f = builtins.foldl' (f: overlay: lib.extends overlay f) pkgsFun allOverlays;


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.5.21  4.5.23     4.5.23 4.5.23 
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: pass `--verbose` to see 10 unchanged dependencies behind latest
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rowan
  latest: 16 packages

```
### cargo update

```
    Updating crates.io index
     Locking 4 packages to latest compatible versions
    Updating anyhow v1.0.93 -> v1.0.94
    Updating fastrand v2.2.0 -> v2.3.0
    Updating libc v0.2.167 -> v0.2.168
    Updating rustix v0.38.41 -> v0.38.42
    Removing windows-sys v0.52.0
note: pass `--verbose` to see 14 unchanged dependencies behind latest

```
### cargo outdated

```
Name   Project  Compat  Latest  Kind    Platform
----   -------  ------  ------  ----    --------
rowan  0.15.16  ---     0.16.1  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 714 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (90 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre715208.2c15aa59df00/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre716975.929116e31606/nixexprs.tar.xz
-    hash: 1grhv1ryj80261zf0k92jqpvlwbna2r2r2a48as4fgcihv8sn076
+    hash: 1cprm71jkm2m1s5b94z9s4fbvr0f431dl3qdbvy315s6sd870jfp
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 49717b5af6f80172275d47a418c9719a31a78b53
+    revision: 357cda84af1d74626afb7fb3bc12d6957167cda9
-    url: https://github.com/numtide/treefmt-nix/archive/49717b5af6f80172275d47a418c9719a31a78b53.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/357cda84af1d74626afb7fb3bc12d6957167cda9.tar.gz
-    hash: 1lqmya394jiycxdz5mpz8s626bsivix14757dl17b9gbag7xr0r4
+    hash: 17x9xlbzy8mjgwz7mandfsqfixaqv6jmsc0w6g5kqysx6gmak8zn
[INFO ] Update successful.
```
</details>
