### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "autocfg"
@@ -264,9 +264,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa",
  "memchr",
@@ -519,9 +519,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rnix = "0.11.0"
 regex = "1.11.1"
 clap = { version = "4.5.23", features = ["derive"] }
-serde_json = "1.0.133"
+serde_json = "1.0.134"
 tempfile = "3.14.0"
 serde = { version = "1.0.216", features = ["derive"] }
 anyhow = "1.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre721840.71a6392e367b/nixexprs.tar.xz",
-      "hash": "172arjrskqfp9cv4pjs8b9554zy71ff3i594099iw2xvfxzjyly2"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre725756.7e4a1594489d/nixexprs.tar.xz",
+      "hash": "1gzcf1bxm9n3a3hvplyl7w8g7cnybaa5hjqxx94wvd4jd5phivip"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
-      "url": "https://github.com/numtide/treefmt-nix/archive/0ce9d149d99bc383d1f2d85f31f6ebd146e46085.tar.gz",
-      "hash": "1d593wq5l1wq7prw6c989kjwz0kz7bff92yjisv3v96y42adm05k"
+      "revision": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
+      "url": "https://github.com/numtide/treefmt-nix/archive/65712f5af67234dad91a5a4baee986a8b62dbf8f.tar.gz",
+      "hash": "04n0yvp2ya8k6pci0msms05xf6qr3bx86p0lb228r4lwwpivpj1h"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
serde_json 1.0.133 1.0.134    1.0.134 1.0.134
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: rowan
  latest: 16 packages

```
### cargo update

```
    Updating crates.io index
     Locking 3 packages to latest compatible versions
    Updating anyhow v1.0.94 -> v1.0.95
    Updating libc v0.2.168 -> v0.2.169
    Updating syn v2.0.90 -> v2.0.91
note: pass `--verbose` to see 5 unchanged dependencies behind latest

```
### cargo outdated

```
Name   Project  Compat  Latest  Kind    Platform
----   -------  ------  ------  ----    --------
rowan  0.15.16  ---     0.16.1  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 720 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (81 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre721840.71a6392e367b/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre725756.7e4a1594489d/nixexprs.tar.xz
-    hash: 172arjrskqfp9cv4pjs8b9554zy71ff3i594099iw2xvfxzjyly2
+    hash: 1gzcf1bxm9n3a3hvplyl7w8g7cnybaa5hjqxx94wvd4jd5phivip
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 0ce9d149d99bc383d1f2d85f31f6ebd146e46085
+    revision: 65712f5af67234dad91a5a4baee986a8b62dbf8f
-    url: https://github.com/numtide/treefmt-nix/archive/0ce9d149d99bc383d1f2d85f31f6ebd146e46085.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/65712f5af67234dad91a5a4baee986a8b62dbf8f.tar.gz
-    hash: 1d593wq5l1wq7prw6c989kjwz0kz7bff92yjisv3v96y42adm05k
+    hash: 04n0yvp2ya8k6pci0msms05xf6qr3bx86p0lb228r4lwwpivpj1h
[INFO ] Update successful.
```
</details>
