### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -469,18 +469,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -519,9 +519,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ regex = "1.11.1"
 clap = { version = "4.5.23", features = ["derive"] }
 serde_json = "1.0.134"
 tempfile = "3.14.0"
-serde = { version = "1.0.216", features = ["derive"] }
+serde = { version = "1.0.217", features = ["derive"] }
 anyhow = "1.0"
 colored = "2.2.0"
 itertools = "0.13.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre725756.7e4a1594489d/nixexprs.tar.xz",
-      "hash": "1gzcf1bxm9n3a3hvplyl7w8g7cnybaa5hjqxx94wvd4jd5phivip"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre730187.0e82ab234249/nixexprs.tar.xz",
+      "hash": "0s5snh81d5n9zxcn9n2fqk6jcinfd5ys97fcw8qyrs9dlprp1slw"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
-      "url": "https://github.com/numtide/treefmt-nix/archive/65712f5af67234dad91a5a4baee986a8b62dbf8f.tar.gz",
-      "hash": "04n0yvp2ya8k6pci0msms05xf6qr3bx86p0lb228r4lwwpivpj1h"
+      "revision": "56c0ecd79f7ba01a0ec027da015df751d6ca3ae7",
+      "url": "https://github.com/numtide/treefmt-nix/archive/56c0ecd79f7ba01a0ec027da015df751d6ca3ae7.tar.gz",
+      "hash": "1jd8m3xifbgvc2fqfpvgq13m3as2g76yjpscgmcknp4kr2cl1b23"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name  old req compatible latest  new req
====  ======= ========== ======  =======
serde 1.0.216 1.0.217    1.0.217 1.0.217
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: itertools, rowan
  latest: 15 packages

```
### cargo update

```
    Updating crates.io index
     Locking 2 packages to latest compatible versions
    Updating quote v1.0.37 -> v1.0.38
    Updating syn v2.0.91 -> v2.0.93
note: pass `--verbose` to see 6 unchanged dependencies behind latest

```
### cargo outdated

```
Name       Project  Compat  Latest  Kind    Platform
----       -------  ------  ------  ----    --------
itertools  0.13.0   ---     0.14.0  Normal  ---
rowan      0.15.16  ---     0.16.1  Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 722 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (81 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre725756.7e4a1594489d/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre730187.0e82ab234249/nixexprs.tar.xz
-    hash: 1gzcf1bxm9n3a3hvplyl7w8g7cnybaa5hjqxx94wvd4jd5phivip
+    hash: 0s5snh81d5n9zxcn9n2fqk6jcinfd5ys97fcw8qyrs9dlprp1slw
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 65712f5af67234dad91a5a4baee986a8b62dbf8f
+    revision: 56c0ecd79f7ba01a0ec027da015df751d6ca3ae7
-    url: https://github.com/numtide/treefmt-nix/archive/65712f5af67234dad91a5a4baee986a8b62dbf8f.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/56c0ecd79f7ba01a0ec027da015df751d6ca3ae7.tar.gz
-    hash: 04n0yvp2ya8k6pci0msms05xf6qr3bx86p0lb228r4lwwpivpj1h
+    hash: 1jd8m3xifbgvc2fqfpvgq13m3as2g76yjpscgmcknp4kr2cl1b23
[INFO ] Update successful.
```
</details>
