### PR TITLE
Make xrefcheck ignore intentionally invalid symlinks

### DIFF
--- a/xrefcheck.yaml
+++ b/xrefcheck.yaml
@@ -1,0 +1,109 @@
+# Generated using `xrefcheck dump-config -t GitHub` at version 0.3.1
+
+# Exclusion parameters.
+exclusions:
+  # Ignore these files. References to them will fail verification,
+  # and references from them will not be verified.
+  # List of glob patterns.
+  ignore: []
+
+  # References from these files will not be verified.
+  # List of glob patterns.
+  ignoreRefsFrom:
+    - .github/pull_request_template.md
+    - .github/issue_template.md
+    - .github/PULL_REQUEST_TEMPLATE/**/*
+    - .github/ISSUE_TEMPLATE/**/*
+
+  # References to these paths will not be verified.
+  # List of glob patterns.
+  ignoreLocalRefsTo:
+    - ../../../issues
+    - ../../../issues/*
+    - ../../../pulls
+    - ../../../pulls/*
+
+  # References to these URIs will not be verified.
+  # List of POSIX extended regular expressions.
+  ignoreExternalRefsTo:
+    # Ignore localhost links by default
+    - (https?|ftps?)://(localhost|127\.0\.0\.1).*
+
+# Networking parameters.
+networking:
+  # When checking external references, how long to wait on request before
+  # declaring "Response timeout".
+  externalRefCheckTimeout: 10s
+
+  # Skip links which return 403 or 401 code.
+  ignoreAuthFailures: true
+
+  # When a verification result is a "429 Too Many Requests" response
+  # and it does not contain a "Retry-After" header,
+  # wait this amount of time before attempting to verify the link again.
+  defaultRetryAfter: 30s
+
+  # How many attempts to retry an external link after getting
+  # a "429 Too Many Requests" response.
+  # Timeouts may also be accounted here, see the description
+  # of `maxTimeoutRetries` field.
+
+  # If a site once responded with 429 error code, subsequent
+  # request timeouts will also be treated as hitting the site's
+  # rate limiter and result in retry attempts, unless the
+  # maximum retries number has been reached.
+  #
+  # On other errors xrefcheck fails immediately, without retrying.
+  maxRetries: 3
+
+  # Querying a given domain that ever returned 429 before,
+  # this defines how many timeouts are allowed during retries.
+  #
+  # For such domains, timeouts likely mean hitting the rate limiter,
+  # and so xrefcheck considers timeouts in the same way as 429 errors.
+  #
+  # For other domains, a timeout results in a respective error, no retry
+  # attempts will be performed. Use `externalRefCheckTimeout` option
+  # to increase the time after which timeout is declared.
+  #
+  # This option is similar to `maxRetries`, the difference is that
+  # this `maxTimeoutRetries` option limits only the number of retries
+  # caused by timeouts, and `maxRetries` limits the number of retries
+  # caused both by 429s and timeouts.
+  maxTimeoutRetries: 1
+
+  # Maximum number of links that can be followed in a single redirect
+  # chain.
+  #
+  # The link is considered as invalid if the limit is exceeded.
+  maxRedirectFollows: 10
+
+  # Rules to override the redirect behavior for external references that
+  # match, where
+  #   - 'from' is a regular expression for the source link in a single
+  #     redirection step. Its absence means that every link matches.
+  #   - 'to' is a regular expression for the target link in a single
+  #     redirection step. Its absence also means that every link matches.
+  #   - 'on' accepts 'temporary', 'permanent' or a specific redirect HTTP code.
+  #     Its absence also means that every response code matches.
+  #   - 'outcome' accepts 'valid', 'invalid' or 'follow'. The last one follows
+  #      the redirect by applying the same configuration rules so, for instance,
+  #      exclusion rules would also apply to the following links.
+  #
+  # The first one that matches is applied, and the link is considered
+  # as valid if none of them does match.
+  externalRefRedirects:
+    - on: permanent
+      outcome: invalid
+
+# Parameters of scanners for various file types.
+scanners:
+  # On 'anchor not found' error, how much similar anchors should be displayed as
+  # hint. Number should be between 0 and 1, larger value means stricter filter.
+  anchorSimilarityThreshold: 0.5
+
+  markdown:
+    # Flavor of markdown, e.g. GitHub-flavor.
+    #
+    # This affects which anchors are generated for headers.
+    flavor: GitHub

--- a/xrefcheck.yaml
+++ b/xrefcheck.yaml
@@ -1,11 +1,16 @@
-# Generated using `xrefcheck dump-config -t GitHub` at version 0.3.1
+# Initially generated using `xrefcheck dump-config -t GitHub` at version 0.3.1
+# Then adjusted as necessary
 
 # Exclusion parameters.
 exclusions:
   # Ignore these files. References to them will fail verification,
   # and references from them will not be verified.
   # List of glob patterns.
-  ignore: []
+  ignore: [
+    # Intentionally invalid symlinks for testing
+    "tests/multiple-failures/pkgs/by-name/A/fo@/foo",
+    "tests/symlink-invalid/pkgs/by-name/fo/foo/foo",
+  ]
 
   # References from these files will not be verified.
   # List of glob patterns.


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs-vet/actions/runs/12776335415/job/35614770890?pr=144 by adding a default `xrefcheck.yaml` file and then adding explicit ignores for the intentionally invalid symlinks.