### PR TITLE
Update nixpkgs-check-by-name reference in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @NixOS/nixpkgs-check-by-name
+* @NixOS/nixpkgs-vet


### PR DESCRIPTION
It's @NixOS/nixpkgs-vet now :)