### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,11 +52,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys",
 ]
 
@@ -74,9 +75,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "cfg-if"
@@ -500,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rnix = "0.11.0"
 regex = "1.11.1"
 clap = { version = "4.5.26", features = ["derive"] }
-serde_json = "1.0.135"
+serde_json = "1.0.137"
 tempfile = "3.15.0"
 serde = { version = "1.0.217", features = ["derive"] }
 anyhow = "1.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre737149.2fdec2c2e68b/nixexprs.tar.xz",
-      "hash": "1jcs6m0625jq3bmn7xf4q8ix71yciwy06hx0b28dfzvk9wgjswdz"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre740306.aa6ae0afa6ad/nixexprs.tar.xz",
+      "hash": "09pins4v5wpby1sw5p165bsg07fy8w6w90xxhin59v45bfn4hrm1"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
-      "url": "https://github.com/numtide/treefmt-nix/archive/13c913f5deb3a5c08bb810efd89dc8cb24dd968b.tar.gz",
-      "hash": "177i5879l5dfpzyq8dj9cflr19clcm48hs502043dp8r2k3gqsm7"
+      "revision": "d1ed3b385f8130e392870cfb1dbfaff8a63a1899",
+      "url": "https://github.com/numtide/treefmt-nix/archive/d1ed3b385f8130e392870cfb1dbfaff8a63a1899.tar.gz",
+      "hash": "1mx82xv8sw1c5pqig6nyvk6iyfz6j487vkkicginfqz1hrqmdwxq"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
serde_json 1.0.135 1.0.137    1.0.137 1.0.137
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: 4 packages
  latest: 13 packages

```
### cargo update

```
    Updating crates.io index
     Locking 2 packages to latest compatible versions
    Updating anstyle-wincon v3.0.6 -> v3.0.7
    Updating bitflags v2.7.0 -> v2.8.0
note: pass `--verbose` to see 4 unchanged dependencies behind latest

```
### cargo outdated

```
Name                  Project  Compat  Latest   Kind    Platform
----                  -------  ------  ------   ----    --------
colored               2.2.0    ---     3.0.0    Normal  ---
colored->lazy_static  1.5.0    ---     Removed  Normal  ---
itertools             0.13.0   ---     0.14.0   Normal  ---
rnix                  0.11.0   ---     0.12.0   Normal  ---
rowan                 0.15.16  ---     0.16.1   Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 725 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (83 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre737149.2fdec2c2e68b/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre740306.aa6ae0afa6ad/nixexprs.tar.xz
-    hash: 1jcs6m0625jq3bmn7xf4q8ix71yciwy06hx0b28dfzvk9wgjswdz
+    hash: 09pins4v5wpby1sw5p165bsg07fy8w6w90xxhin59v45bfn4hrm1
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: 13c913f5deb3a5c08bb810efd89dc8cb24dd968b
+    revision: d1ed3b385f8130e392870cfb1dbfaff8a63a1899
-    url: https://github.com/numtide/treefmt-nix/archive/13c913f5deb3a5c08bb810efd89dc8cb24dd968b.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/d1ed3b385f8130e392870cfb1dbfaff8a63a1899.tar.gz
-    hash: 177i5879l5dfpzyq8dj9cflr19clcm48hs502043dp8r2k3gqsm7
+    hash: 1mx82xv8sw1c5pqig6nyvk6iyfz6j487vkkicginfqz1hrqmdwxq
[INFO ] Update successful.
```
</details>
