### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -456,9 +456,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unicode-linebreak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.11.1"
-clap = { version = "4.5.26", features = ["derive"] }
+clap = { version = "4.5.27", features = ["derive"] }
 serde_json = "1.0.137"
 tempfile = "3.15.0"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre740306.aa6ae0afa6ad/nixexprs.tar.xz",
-      "hash": "09pins4v5wpby1sw5p165bsg07fy8w6w90xxhin59v45bfn4hrm1"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre744509.88a55dffa4d4/nixexprs.tar.xz",
+      "hash": "031apspqfm8z4yczj8126chfc7mijnmnxzqg0inaz1dwi4pzwlbz"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "d1ed3b385f8130e392870cfb1dbfaff8a63a1899",
-      "url": "https://github.com/numtide/treefmt-nix/archive/d1ed3b385f8130e392870cfb1dbfaff8a63a1899.tar.gz",
-      "hash": "1mx82xv8sw1c5pqig6nyvk6iyfz6j487vkkicginfqz1hrqmdwxq"
+      "revision": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
+      "url": "https://github.com/numtide/treefmt-nix/archive/f2cc121df15418d028a59c9737d38e3a90fbaf8f.tar.gz",
+      "hash": "0yp9h1c8d99ilj75ixli3702jf0cxiwq6hg0f1rc7wjlmv1ga2g4"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.5.26  4.5.27     4.5.27 4.5.27 
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: 4 packages
  latest: 13 packages

```
### cargo update

```
    Updating crates.io index
     Locking 2 packages to latest compatible versions
    Updating rustix v0.38.43 -> v0.38.44
    Updating unicode-ident v1.0.14 -> v1.0.15
note: pass `--verbose` to see 4 unchanged dependencies behind latest

```
### cargo outdated

```
Name                  Project  Compat  Latest   Kind    Platform
----                  -------  ------  ------   ----    --------
colored               2.2.0    ---     3.0.0    Normal  ---
colored->lazy_static  1.5.0    ---     Removed  Normal  ---
itertools             0.13.0   ---     0.14.0   Normal  ---
rnix                  0.11.0   ---     0.12.0   Normal  ---
rowan                 0.15.16  ---     0.16.1   Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 726 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (83 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre740306.aa6ae0afa6ad/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre744509.88a55dffa4d4/nixexprs.tar.xz
-    hash: 09pins4v5wpby1sw5p165bsg07fy8w6w90xxhin59v45bfn4hrm1
+    hash: 031apspqfm8z4yczj8126chfc7mijnmnxzqg0inaz1dwi4pzwlbz
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: d1ed3b385f8130e392870cfb1dbfaff8a63a1899
+    revision: f2cc121df15418d028a59c9737d38e3a90fbaf8f
-    url: https://github.com/numtide/treefmt-nix/archive/d1ed3b385f8130e392870cfb1dbfaff8a63a1899.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/f2cc121df15418d028a59c9737d38e3a90fbaf8f.tar.gz
-    hash: 1mx82xv8sw1c5pqig6nyvk6iyfz6j487vkkicginfqz1hrqmdwxq
+    hash: 0yp9h1c8d99ilj75ixli3702jf0cxiwq6hg0f1rc7wjlmv1ga2g4
[INFO ] Update successful.
```
</details>
