### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,13 +220,14 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -469,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "scopeguard"
@@ -501,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -531,9 +532,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -551,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -582,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-linebreak"
@@ -612,9 +613,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -688,6 +692,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 rnix = "0.11.0"
 regex = "1.11.1"
 clap = { version = "4.5.27", features = ["derive"] }
-serde_json = "1.0.137"
-tempfile = "3.15.0"
+serde_json = "1.0.138"
+tempfile = "3.16.0"
 serde = { version = "1.0.217", features = ["derive"] }
 anyhow = "1.0"
 colored = "2.2.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre744509.88a55dffa4d4/nixexprs.tar.xz",
-      "hash": "031apspqfm8z4yczj8126chfc7mijnmnxzqg0inaz1dwi4pzwlbz"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre746674.6c4e0724e0a7/nixexprs.tar.xz",
+      "hash": "0n0h27hpkyn29g68llgzb0npsgbcns1qs20qygd542087i07wqq1"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -14,9 +14,9 @@
         "repo": "treefmt-nix"
       },
       "branch": "main",
-      "revision": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
-      "url": "https://github.com/numtide/treefmt-nix/archive/f2cc121df15418d028a59c9737d38e3a90fbaf8f.tar.gz",
-      "hash": "0yp9h1c8d99ilj75ixli3702jf0cxiwq6hg0f1rc7wjlmv1ga2g4"
+      "revision": "bebf27d00f7d10ba75332a0541ac43676985dea3",
+      "url": "https://github.com/numtide/treefmt-nix/archive/bebf27d00f7d10ba75332a0541ac43676985dea3.tar.gz",
+      "hash": "1ng0b9fp8h1bp1im6wp7czmjnlysym8vndk61v3c85n2dgbw5a4g"
     }
   },
   "version": 3


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
serde_json 1.0.137 1.0.138    1.0.138 1.0.138
tempfile   3.15.0  3.16.0     3.16.0  3.16.0 
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: 4 packages
  latest: 12 packages

```
### cargo update

```
    Updating crates.io index
     Locking 3 packages to latest compatible versions
    Updating ryu v1.0.18 -> v1.0.19
    Updating syn v2.0.96 -> v2.0.98
    Updating unicode-ident v1.0.15 -> v1.0.16
note: pass `--verbose` to see 4 unchanged dependencies behind latest

```
### cargo outdated

```
Name                  Project  Compat  Latest   Kind    Platform
----                  -------  ------  ------   ----    --------
colored               2.2.0    ---     3.0.0    Normal  ---
colored->lazy_static  1.5.0    ---     Removed  Normal  ---
itertools             0.13.0   ---     0.14.0   Normal  ---
rnix                  0.11.0   ---     0.12.0   Normal  ---
rowan                 0.15.16  ---     0.16.1   Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 729 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (84 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre744509.88a55dffa4d4/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre746674.6c4e0724e0a7/nixexprs.tar.xz
-    hash: 031apspqfm8z4yczj8126chfc7mijnmnxzqg0inaz1dwi4pzwlbz
+    hash: 0n0h27hpkyn29g68llgzb0npsgbcns1qs20qygd542087i07wqq1
[INFO ] Updating 'treefmt-nix' …
Changes:
-    revision: f2cc121df15418d028a59c9737d38e3a90fbaf8f
+    revision: bebf27d00f7d10ba75332a0541ac43676985dea3
-    url: https://github.com/numtide/treefmt-nix/archive/f2cc121df15418d028a59c9737d38e3a90fbaf8f.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/bebf27d00f7d10ba75332a0541ac43676985dea3.tar.gz
-    hash: 0yp9h1c8d99ilj75ixli3702jf0cxiwq6hg0f1rc7wjlmv1ga2g4
+    hash: 1ng0b9fp8h1bp1im6wp7czmjnlysym8vndk61v3c85n2dgbw5a4g
[INFO ] Update successful.
```
</details>
