### PR TITLE
Automated update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
 
       - name: build
         run: nix-build -A ci

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           path: repo
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
 
       - name: Run update script
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
@@ -244,9 +244,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -283,9 +283,9 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
 name = "lock_api"
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -457,9 +457,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
 dependencies = [
  "bitflags",
  "errno",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
@@ -482,18 +482,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -532,9 +532,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -572,9 +572,9 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-linebreak"
@@ -595,9 +595,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ rnix = "0.11.0"
 regex = "1.11.1"
 clap = { version = "4.5.31", features = ["derive"] }
 serde_json = "1.0.140"
-tempfile = "3.17.1"
-serde = { version = "1.0.218", features = ["derive"] }
+tempfile = "3.18.0"
+serde = { version = "1.0.219", features = ["derive"] }
 anyhow = "1.0"
 colored = "2.2.0"
 itertools = "0.13.0"
 rowan = "0.15.16"
-indoc = "2.0.5"
+indoc = "2.0.6"
 relative-path = "1.9.3"
-textwrap = "0.16.1"
+textwrap = "0.16.2"
 derive-enum-from-into = "0.2.0"
 derive-new = "0.7.0"
 derive_more = { version = "1.0.0", features = ["display"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre761400.b58e19b11fe7/nixexprs.tar.xz",
-      "hash": "03bjrrg447w7z96gl3m7l73sh7qvd5lvpcn9n4fa4s85ypc9xqrn"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre764610.2d9e4457f8e8/nixexprs.tar.xz",
+      "hash": "1b20cshhsxaxh7iryl52b2hnwpc0q1hz1g4mhy78149059436065"
     },
     "treefmt-nix": {
       "type": "Git",


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name     old req compatible latest  new req
====     ======= ========== ======  =======
tempfile 3.17.1  3.18.0     3.18.0  3.18.0 
serde    1.0.218 1.0.219    1.0.219 1.0.219
indoc    2.0.5   2.0.6      2.0.6   2.0.6  
textwrap 0.16.1  0.16.2     0.16.2  0.16.2 
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: 5 packages
  latest: 9 packages

```
### cargo update

```
    Updating crates.io index
     Locking 6 packages to latest compatible versions
    Updating either v1.14.0 -> v1.15.0
    Updating itoa v1.0.14 -> v1.0.15
    Updating redox_syscall v0.5.9 -> v0.5.10
    Updating ryu v1.0.19 -> v1.0.20
    Updating syn v2.0.99 -> v2.0.100
    Updating unicode-ident v1.0.17 -> v1.0.18
note: pass `--verbose` to see 5 unchanged dependencies behind latest

```
### cargo outdated

```
Name                           Project  Compat  Latest   Kind    Platform
----                           -------  ------  ------   ----    --------
colored                        2.2.0    ---     3.0.0    Normal  ---
colored->lazy_static           1.5.0    ---     Removed  Normal  ---
derive_more                    1.0.0    ---     2.0.1    Normal  ---
derive_more->derive_more-impl  1.0.0    ---     2.0.1    Normal  ---
itertools                      0.13.0   ---     0.14.0   Normal  ---
rnix                           0.11.0   ---     0.12.0   Normal  ---
rowan                          0.15.16  ---     0.16.1   Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 741 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (84 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

Bumps the actions group with 1 update: [cachix/install-nix-action](https://github.com/cachix/install-nix-action).

Updates `cachix/install-nix-action` from 30 to 31
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/cachix/install-nix-action/releases">cachix/install-nix-action's releases</a>.</em></p>
<blockquote>
<h2>v31</h2>
<h2>What's Changed</h2>
<ul>
<li>nix: 2.24.9 -&gt; 2.25.2 by <a href="https://github.com/Mic92"><code>@​Mic92</code></a> in <a href="https://redirect.github.com/cachix/install-nix-action/pull/218">cachix/install-nix-action#218</a></li>
<li>ci: fix latest installer tests by <a href="https://github.com/sandydoo"><code>@​sandydoo</code></a> in <a href="https://redirect.github.com/cachix/install-nix-action/pull/220">cachix/install-nix-action#220</a></li>
<li>ci: add ubuntu-24.04-arm to matrix by <a href="https://github.com/msgilligan"><code>@​msgilligan</code></a> in <a href="https://redirect.github.com/cachix/install-nix-action/pull/221">cachix/install-nix-action#221</a></li>
<li>nix: 2.25.2 -&gt; 2.26.2 by <a href="https://github.com/Mic92"><code>@​Mic92</code></a> in <a href="https://redirect.github.com/cachix/install-nix-action/pull/226">cachix/install-nix-action#226</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/msgilligan"><code>@​msgilligan</code></a> made their first contribution in <a href="https://redirect.github.com/cachix/install-nix-action/pull/221">cachix/install-nix-action#221</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/cachix/install-nix-action/compare/v30...v31">https://github.com/cachix/install-nix-action/compare/v30...v31</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/cachix/install-nix-action/commit/91a071959513ca103b54280ac0bef5b825791d4d"><code>91a0719</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/226">#226</a> from Mic92/nix-update</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/d81eadf041318952daecfb82fe8d7b4538067642"><code>d81eadf</code></a> nix: 2.25.2 -&gt; 2.26.2</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/3d69a1d4d262a7fb63731d2bc0d081544705e3d5"><code>3d69a1d</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/221">#221</a> from msgilligan/msgilligan/github-test-aarch64-linux</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/265a04a520d4a95357365b3a9c2e73135a8e9830"><code>265a04a</code></a> GitHub test.yml: add ubuntu-24.04-arm to matrix</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/89fd1e98db16430dad3d6595e0f6d30718059e4e"><code>89fd1e9</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/220">#220</a> from cachix/fix-master-tests</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/a76df16350261308addb51d2386f28f5f0975987"><code>a76df16</code></a> ci: bump nixpkgs channel</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/a49b703498f43e1426a1b820f27cf12cad57143f"><code>a49b703</code></a> ci: fix act test</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/f3f544c44bee9e88b5ab7976e42c675083a4f60b"><code>f3f544c</code></a> ci: fix latest installer tests</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/14344b39ca74ae462b171571696461d555318cc3"><code>14344b3</code></a> Merge pull request <a href="https://redirect.github.com/cachix/install-nix-action/issues/218">#218</a> from Mic92/nix-upgrade</li>
<li><a href="https://github.com/cachix/install-nix-action/commit/b1deb06f62baf2f4c1604bc301787f127e990349"><code>b1deb06</code></a> nix: 2.24.9 -&gt; 2.25.2</li>
<li>See full diff in <a href="https://github.com/cachix/install-nix-action/compare/v30...v31">compare view</a></li>
</ul>
</details>
<br />

</details>
<details><summary>npins changes</summary>

```
[INFO ] Updating 'nixpkgs' …
Changes:
-    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre761400.b58e19b11fe7/nixexprs.tar.xz
+    url: https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre764610.2d9e4457f8e8/nixexprs.tar.xz
-    hash: 03bjrrg447w7z96gl3m7l73sh7qvd5lvpcn9n4fa4s85ypc9xqrn
+    hash: 1b20cshhsxaxh7iryl52b2hnwpc0q1hz1g4mhy78149059436065
[INFO ] Updating 'treefmt-nix' …
(no changes)
[INFO ] Update successful.
```
</details>
