### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "cfg-if"
@@ -87,9 +87,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -204,9 +204,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.11.1"
-clap = { version = "4.5.37", features = ["derive"] }
+clap = { version = "4.5.38", features = ["derive"] }
 serde_json = "1.0.140"
-tempfile = "3.19.1"
+tempfile = "3.20.0"
 serde = { version = "1.0.219", features = ["derive"] }
 anyhow = "1.0"
 colored = "2.2.0"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "2f7500238f6e2eafa64fb121b3893c3d6597b3fd",
-      "url": "https://github.com/nixos/nixpkgs/archive/2f7500238f6e2eafa64fb121b3893c3d6597b3fd.tar.gz",
-      "hash": "0wq9lp0q8qr3w4ryxjjxlk1jgp0bznv7rr9x4v470zz9rvcyi5sl"
+      "revision": "cc9c4b607e7b1a6fd25b16d5951b39077e7f2218",
+      "url": "https://github.com/nixos/nixpkgs/archive/cc9c4b607e7b1a6fd25b16d5951b39077e7f2218.tar.gz",
+      "hash": "0b86n57286552vp1gix9jasgiqj913r1nk8wxssfhpcdfpv1d1vg"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "29ec5026372e0dec56f890e50dbe4f45930320fd",
-      "url": "https://github.com/numtide/treefmt-nix/archive/29ec5026372e0dec56f890e50dbe4f45930320fd.tar.gz",
-      "hash": "07p78w5f095aw8gb507bl67gd2zzgkrmbp60h1vsnap4pzafq7g2"
+      "revision": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
+      "url": "https://github.com/numtide/treefmt-nix/archive/ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb.tar.gz",
+      "hash": "0f6fdrmjmcbflbqmnbfymfd82q4r9448hxjhkfxajdk846v6k3bf"
     }
   },
   "version": 5


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name     old req compatible latest new req
====     ======= ========== ====== =======
clap     4.5.37  4.5.38     4.5.38 4.5.38 
tempfile 3.19.1  3.20.0     3.20.0 3.20.0 
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: 6 packages
  latest: 10 packages

```
### cargo update

```
    Updating crates.io index
     Locking 2 packages to latest compatible versions
    Updating bitflags v2.9.0 -> v2.9.1
    Updating errno v0.3.11 -> v0.3.12
note: pass `--verbose` to see 6 unchanged dependencies behind latest

```
### cargo outdated

```
Name                           Project  Compat  Latest   Kind    Platform
----                           -------  ------  ------   ----    --------
colored                        2.2.0    ---     3.0.0    Normal  ---
colored->lazy_static           1.5.0    ---     Removed  Normal  ---
derive_more                    1.0.0    ---     2.0.1    Normal  ---
derive_more->derive_more-impl  1.0.0    ---     2.0.1    Normal  ---
itertools                      0.13.0   ---     0.14.0   Normal  ---
relative-path                  1.9.3    ---     2.0.1    Normal  ---
rnix                           0.11.0   ---     0.12.0   Normal  ---
rowan                          0.15.16  ---     0.16.1   Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 781 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (85 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: 29ec5026372e0dec56f890e50dbe4f45930320fd
+    revision: ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb
-    url: https://github.com/numtide/treefmt-nix/archive/29ec5026372e0dec56f890e50dbe4f45930320fd.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb.tar.gz
-    hash: 07p78w5f095aw8gb507bl67gd2zzgkrmbp60h1vsnap4pzafq7g2
+    hash: 0f6fdrmjmcbflbqmnbfymfd82q4r9448hxjhkfxajdk846v6k3bf
[nixpkgs] Changes:
-    revision: 2f7500238f6e2eafa64fb121b3893c3d6597b3fd
+    revision: cc9c4b607e7b1a6fd25b16d5951b39077e7f2218
-    url: https://github.com/nixos/nixpkgs/archive/2f7500238f6e2eafa64fb121b3893c3d6597b3fd.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/cc9c4b607e7b1a6fd25b16d5951b39077e7f2218.tar.gz
-    hash: 0wq9lp0q8qr3w4ryxjjxlk1jgp0bznv7rr9x4v470zz9rvcyi5sl
+    hash: 0b86n57286552vp1gix9jasgiqj913r1nk8wxssfhpcdfpv1d1vg
[INFO ] Update successful.
```
</details>
