### PR TITLE
.github: run CI with `max-jobs` set to 1 in order to avoid OOM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            max-jobs = 1
 
       - name: build
         run: nix-build -A ci

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,6 +14,9 @@ jobs:
           path: repo
 
       - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            max-jobs = 1
 
       - name: Run update script
         run: |

--- a/default.nix
+++ b/default.nix
@@ -162,11 +162,11 @@ let
 
     # Tests the tool on the pinned Nixpkgs tree with various Nix and Lix versions.
     # This allows exposure to changes in behavior from Nix and Nix-alikes.
-    #nixpkgsCheckWithLatestNix = packages.nixpkgsCheck.nixVersions.latest;
-    #nixpkgsCheckWithGitNix = packages.nixpkgsCheck.nixVersions.git;
-    #nixpkgsCheckWithMinimumNix = packages.nixpkgsCheck.nixVersions.minimum;
-    #nixpkgsCheckWithStableLix = packages.nixpkgsCheck.lixVersions.stable;
-    #nixpkgsCheckWithLatestLix = packages.nixpkgsCheck.lixVersions.latest;
+    nixpkgsCheckWithLatestNix = packages.nixpkgsCheck.nixVersions.latest;
+    nixpkgsCheckWithGitNix = packages.nixpkgsCheck.nixVersions.git;
+    nixpkgsCheckWithMinimumNix = packages.nixpkgsCheck.nixVersions.minimum;
+    nixpkgsCheckWithStableLix = packages.nixpkgsCheck.lixVersions.stable;
+    nixpkgsCheckWithLatestLix = packages.nixpkgsCheck.lixVersions.latest;
   };
 in
 packages


### PR DESCRIPTION
As suggested by @dtomvan in [this comment](https://github.com/NixOS/nixpkgs-vet/pull/158#issuecomment-2869670960), try to avoid OOM through `max-jobs = 1`.

I'm planning on self-merging if it goes through CI successfully, because I regressed these checks trying to fix the update process.