### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,12 +52,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
@@ -87,9 +87,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -289,9 +289,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -334,10 +334,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -345,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 rnix = "0.11.0"
 regex = "1.11.1"
-clap = { version = "4.5.38", features = ["derive"] }
+clap = { version = "4.5.39", features = ["derive"] }
 serde_json = "1.0.140"
 tempfile = "3.20.0"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "cc9c4b607e7b1a6fd25b16d5951b39077e7f2218",
-      "url": "https://github.com/nixos/nixpkgs/archive/cc9c4b607e7b1a6fd25b16d5951b39077e7f2218.tar.gz",
-      "hash": "0b86n57286552vp1gix9jasgiqj913r1nk8wxssfhpcdfpv1d1vg"
+      "revision": "3ac76b8cc76f259d639b0972a5547880a835652d",
+      "url": "https://github.com/nixos/nixpkgs/archive/3ac76b8cc76f259d639b0972a5547880a835652d.tar.gz",
+      "hash": "03jvgndv69p9k62lm6sf23rdh0f6fxm331v1w8rr5pp9bwxsf2g6"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
-      "url": "https://github.com/numtide/treefmt-nix/archive/ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb.tar.gz",
-      "hash": "0f6fdrmjmcbflbqmnbfymfd82q4r9448hxjhkfxajdk846v6k3bf"
+      "revision": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
+      "url": "https://github.com/numtide/treefmt-nix/archive/1f3f7b784643d488ba4bf315638b2b0a4c5fb007.tar.gz",
+      "hash": "13qisjalw9qvd6lkd9g8225r46j5wdjrp3zw6jrs81q2vxwdz37m"
     }
   },
   "version": 5


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.5.38  4.5.39     4.5.39 4.5.39 
   Upgrading recursive dependencies
     Locking 0 packages to latest compatible versions
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: 6 packages
  latest: 11 packages

```
### cargo update

```
    Updating crates.io index
     Locking 5 packages to latest compatible versions
    Updating anstyle-wincon v3.0.7 -> v3.0.8
    Updating lock_api v0.4.12 -> v0.4.13
      Adding once_cell_polyfill v1.70.1
    Updating parking_lot v0.12.3 -> v0.12.4
    Updating parking_lot_core v0.9.10 -> v0.9.11
note: pass `--verbose` to see 6 unchanged dependencies behind latest

```
### cargo outdated

```
Name                           Project  Compat  Latest   Kind    Platform
----                           -------  ------  ------   ----    --------
colored                        2.2.0    ---     3.0.0    Normal  ---
colored->lazy_static           1.5.0    ---     Removed  Normal  ---
derive_more                    1.0.0    ---     2.0.1    Normal  ---
derive_more->derive_more-impl  1.0.0    ---     2.0.1    Normal  ---
itertools                      0.13.0   ---     0.14.0   Normal  ---
relative-path                  1.9.3    ---     2.0.1    Normal  ---
rnix                           0.11.0   ---     0.12.0   Normal  ---
rowan                          0.15.16  ---     0.16.1   Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 784 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (86 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb
+    revision: 1f3f7b784643d488ba4bf315638b2b0a4c5fb007
-    url: https://github.com/numtide/treefmt-nix/archive/ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/1f3f7b784643d488ba4bf315638b2b0a4c5fb007.tar.gz
-    hash: 0f6fdrmjmcbflbqmnbfymfd82q4r9448hxjhkfxajdk846v6k3bf
+    hash: 13qisjalw9qvd6lkd9g8225r46j5wdjrp3zw6jrs81q2vxwdz37m
[nixpkgs] Changes:
-    revision: cc9c4b607e7b1a6fd25b16d5951b39077e7f2218
+    revision: 3ac76b8cc76f259d639b0972a5547880a835652d
-    url: https://github.com/nixos/nixpkgs/archive/cc9c4b607e7b1a6fd25b16d5951b39077e7f2218.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/3ac76b8cc76f259d639b0972a5547880a835652d.tar.gz
-    hash: 0b86n57286552vp1gix9jasgiqj913r1nk8wxssfhpcdfpv1d1vg
+    hash: 03jvgndv69p9k62lm6sf23rdh0f6fxm331v1w8rr5pp9bwxsf2g6
[INFO ] Update successful.
```
</details>
