### PR TITLE
Automated update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,33 +28,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -127,9 +127,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smawk"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "3ac76b8cc76f259d639b0972a5547880a835652d",
-      "url": "https://github.com/nixos/nixpkgs/archive/3ac76b8cc76f259d639b0972a5547880a835652d.tar.gz",
-      "hash": "03jvgndv69p9k62lm6sf23rdh0f6fxm331v1w8rr5pp9bwxsf2g6"
+      "revision": "551c0c45c948e92a5173e3ad114a07a979806123",
+      "url": "https://github.com/nixos/nixpkgs/archive/551c0c45c948e92a5173e3ad114a07a979806123.tar.gz",
+      "hash": "1hgq8lc5lrc6470lv1jbm1qmv4zrdg2rf5nis7snfykm5jr7dkfz"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
-      "url": "https://github.com/numtide/treefmt-nix/archive/1f3f7b784643d488ba4bf315638b2b0a4c5fb007.tar.gz",
-      "hash": "13qisjalw9qvd6lkd9g8225r46j5wdjrp3zw6jrs81q2vxwdz37m"
+      "revision": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+      "url": "https://github.com/numtide/treefmt-nix/archive/a05be418a1af1198ca0f63facb13c985db4cb3c5.tar.gz",
+      "hash": "1yadm9disc59an4a6c1zidq82530rd7i7idzzsirv6dlwirbqk3q"
     }
   },
   "version": 5


### PR DESCRIPTION
<details><summary>cargo changes</summary>

### cargo upgrade

```
    Checking nixpkgs-vet's dependencies
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: 6 packages
  latest: 12 packages

```
### cargo update

```
    Updating crates.io index
     Locking 7 packages to latest compatible versions
    Updating anstream v0.6.18 -> v0.6.19
    Updating anstyle v1.0.10 -> v1.0.11
    Updating anstyle-parse v0.2.6 -> v0.2.7
    Updating anstyle-query v1.1.2 -> v1.1.3
    Updating anstyle-wincon v3.0.8 -> v3.0.9
    Updating colorchoice v1.0.3 -> v1.0.4
    Updating smallvec v1.15.0 -> v1.15.1
note: pass `--verbose` to see 6 unchanged dependencies behind latest

```
### cargo outdated

```
Name                           Project  Compat  Latest   Kind    Platform
----                           -------  ------  ------   ----    --------
colored                        2.2.0    ---     3.0.0    Normal  ---
colored->lazy_static           1.5.0    ---     Removed  Normal  ---
derive_more                    1.0.0    ---     2.0.1    Normal  ---
derive_more->derive_more-impl  1.0.0    ---     2.0.1    Normal  ---
itertools                      0.13.0   ---     0.14.0   Normal  ---
relative-path                  1.9.3    ---     2.0.1    Normal  ---
rnix                           0.11.0   ---     0.12.0   Normal  ---
rowan                          0.15.16  ---     0.16.1   Normal  ---

```
### cargo audit

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 785 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning repo/Cargo.lock for vulnerabilities (86 crate dependencies)

```
</details>
<details><summary>GitHub Action updates</summary>

</details>
<details><summary>npins changes</summary>

```
[treefmt-nix] Changes:
-    revision: 1f3f7b784643d488ba4bf315638b2b0a4c5fb007
+    revision: a05be418a1af1198ca0f63facb13c985db4cb3c5
-    url: https://github.com/numtide/treefmt-nix/archive/1f3f7b784643d488ba4bf315638b2b0a4c5fb007.tar.gz
+    url: https://github.com/numtide/treefmt-nix/archive/a05be418a1af1198ca0f63facb13c985db4cb3c5.tar.gz
-    hash: 13qisjalw9qvd6lkd9g8225r46j5wdjrp3zw6jrs81q2vxwdz37m
+    hash: 1yadm9disc59an4a6c1zidq82530rd7i7idzzsirv6dlwirbqk3q
[nixpkgs] Changes:
-    revision: 3ac76b8cc76f259d639b0972a5547880a835652d
+    revision: 551c0c45c948e92a5173e3ad114a07a979806123
-    url: https://github.com/nixos/nixpkgs/archive/3ac76b8cc76f259d639b0972a5547880a835652d.tar.gz
+    url: https://github.com/nixos/nixpkgs/archive/551c0c45c948e92a5173e3ad114a07a979806123.tar.gz
-    hash: 03jvgndv69p9k62lm6sf23rdh0f6fxm331v1w8rr5pp9bwxsf2g6
+    hash: 1hgq8lc5lrc6470lv1jbm1qmv4zrdg2rf5nis7snfykm5jr7dkfz
[INFO ] Update successful.
```
</details>
